### PR TITLE
👷 ci: Update build-and-release workflow for DMG creation process

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,14 +40,15 @@ jobs:
 
       - name: Prepare for DMG
         run: |
-          mkdir -p dist
-          mv build/export/MacMusicPlayer.app dist/
-          ls -R dist
+          mkdir -p dist/dmg_temp
+          mv build/export/MacMusicPlayer.app dist/dmg_temp/
+          ln -s /Applications dist/dmg_temp/Applications
+          ls -R dist/dmg_temp
 
       - name: Create DMG
         run: |
           hdiutil create -volname MacMusicPlayer \
-            -srcfolder dist \
+            -srcfolder dist/dmg_temp \
             -ov -format UDZO dist/MacMusicPlayer.dmg
 
       - name: Create Release and Upload Asset


### PR DESCRIPTION
Refactor the DMG creation steps in the GitHub Actions workflow. Move the app to a temporary directory for better organization and create a symbolic link to the Applications folder. This improves the clarity and structure of the build process.