### PR TITLE
Ensure status menu items target app delegate

### DIFF
--- a/MacMusicPlayer/AppDelegate.swift
+++ b/MacMusicPlayer/AppDelegate.swift
@@ -8,13 +8,14 @@
 import Cocoa
 import MediaPlayer
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
     var playerManager: PlayerManager!
     var sleepManager: SleepManager!
     var launchManager: LaunchManager!
     var libraryManager: LibraryManager!
-    var menu: NSMenu!
+    var statusMenuController: StatusMenuController!
 
     private let statusBarSymbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .medium, scale: .medium)
     
@@ -40,10 +41,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let button = statusItem?.button {
             button.target = self
             button.action = #selector(toggleMenu)
-            updateStatusBarIcon()
         }
-        
-        setupMenu()
+
+        statusMenuController = StatusMenuController(
+            playerManager: playerManager,
+            sleepManager: sleepManager,
+            launchManager: launchManager,
+            libraryManager: libraryManager
+        )
+
+        if let statusItem = statusItem {
+            statusMenuController.configureStatusItem(statusItem)
+        }
         setupRemoteCommandCenter()
         
         NotificationCenter.default.addObserver(
@@ -52,113 +61,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             name: NSNotification.Name("AddNewLibrary"),
             object: nil
         )
-    }
-    
-    func setupMenu() {
-        let oldMenu = menu
-        
-        menu = NSMenu()
-        menu.minimumWidth = 200
-        
-        let trackInfoItem = NSMenuItem(title: NSLocalizedString("No Music Source", comment: ""), action: nil, keyEquivalent: "")
-        trackInfoItem.isEnabled = false
-        trackInfoItem.view = NSView(frame: NSRect(x: 0, y: 0, width: 180, height: 20))
-        let trackLabel = NSTextField(frame: NSRect(x: 10, y: 0, width: 160, height: 20))
-        trackLabel.isEditable = false
-        trackLabel.isBordered = false
-        trackLabel.backgroundColor = .clear
-        trackLabel.lineBreakMode = .byTruncatingTail
-        trackInfoItem.view?.addSubview(trackLabel)
-        
-        if let oldMenu = oldMenu,
-           let oldTrackItem = oldMenu.item(at: 0),
-           let oldTrackLabel = oldTrackItem.view?.subviews.first as? NSTextField {
-            trackLabel.stringValue = oldTrackLabel.stringValue
-        } else if let currentTrack = playerManager.currentTrack {
-            trackLabel.stringValue = currentTrack.title
-        }
-        
-        menu.addItem(trackInfoItem)
-        menu.addItem(NSMenuItem.separator())
-        
-        let playPauseTitle = playerManager.isPlaying ? NSLocalizedString("Pause", comment: "") : NSLocalizedString("Play", comment: "")
-        let playPauseItem = NSMenuItem(title: playPauseTitle, action: #selector(togglePlayPause), keyEquivalent: "")
-        menu.addItem(playPauseItem)
-        
-        menu.addItem(NSMenuItem(title: NSLocalizedString("Previous", comment: ""), action: #selector(playPrevious), keyEquivalent: ""))        
-        menu.addItem(NSMenuItem(title: NSLocalizedString("Next", comment: ""), action: #selector(playNext), keyEquivalent: ""))
-        menu.addItem(NSMenuItem.separator())
-
-        menu.addItem(NSMenuItem(title: NSLocalizedString("Browse Songs", comment: "Menu item for browsing and selecting songs"), action: #selector(showSongPickerWindow), keyEquivalent: "f"))
-
-        let playModeMenu = NSMenu()
-        let playModeItem = NSMenuItem(title: NSLocalizedString("Playback Mode", comment: ""), action: nil, keyEquivalent: "")
-        
-        let sequentialItem = NSMenuItem(title: PlayMode.sequential.localizedString, action: #selector(setPlayMode(_:)), keyEquivalent: "")
-        sequentialItem.tag = 0
-        let singleLoopItem = NSMenuItem(title: PlayMode.singleLoop.localizedString, action: #selector(setPlayMode(_:)), keyEquivalent: "")
-        singleLoopItem.tag = 1
-        let randomItem = NSMenuItem(title: PlayMode.random.localizedString, action: #selector(setPlayMode(_:)), keyEquivalent: "")
-        randomItem.tag = 2
-        
-        playModeMenu.addItem(sequentialItem)
-        playModeMenu.addItem(singleLoopItem)
-        playModeMenu.addItem(randomItem)
-        
-        playModeItem.submenu = playModeMenu
-        menu.addItem(playModeItem)
-
-        let libraryMenu = NSMenu()
-        let libraryMenuItem = NSMenuItem(title: NSLocalizedString("Music Libraries", comment: "Menu item for music libraries"), action: nil, keyEquivalent: "")
-        
-        for library in libraryManager.libraries {
-            let item = NSMenuItem(title: library.name, action: #selector(switchLibrary(_:)), keyEquivalent: "")
-            item.representedObject = library.id
-            item.state = libraryManager.currentLibrary?.id == library.id ? .on : .off
-            libraryMenu.addItem(item)
-        }
-        
-        libraryMenu.addItem(NSMenuItem.separator())
-        libraryMenu.addItem(NSMenuItem(title: NSLocalizedString("Refresh Current Library", comment: "Menu item for refreshing current music library"), action: #selector(refreshCurrentLibrary), keyEquivalent: "r"))
-        libraryMenu.addItem(NSMenuItem(title: NSLocalizedString("Add New Library", comment: "Menu item for adding a new music library"), action: #selector(addNewLibrary), keyEquivalent: ""))
-        
-        if libraryManager.libraries.count > 1 {
-            libraryMenu.addItem(NSMenuItem(title: NSLocalizedString("Delete Current Library", comment: "Menu item for deleting current music library"), action: #selector(removeCurrentLibrary), keyEquivalent: ""))
-        }
-        
-        libraryMenu.addItem(NSMenuItem(title: NSLocalizedString("Rename Current Library", comment: "Menu item for renaming current music library"), action: #selector(renameCurrentLibrary), keyEquivalent: ""))
-        
-        libraryMenuItem.submenu = libraryMenu
-        menu.addItem(libraryMenuItem)
-        
-        menu.addItem(NSMenuItem(title: NSLocalizedString("Download Music", comment: ""), action: #selector(showDownloadWindow), keyEquivalent: "d"))
-        
-        let preventSleepItem = NSMenuItem(title: NSLocalizedString("Prevent Mac Sleep", comment: ""), action: #selector(togglePreventSleep), keyEquivalent: "")
-        preventSleepItem.state = sleepManager.preventSleep ? .on : .off
-        menu.addItem(preventSleepItem)
-        
-        let launchAtLoginItem = NSMenuItem(title: NSLocalizedString("Launch at Login", comment: ""), action: #selector(toggleLaunchAtLogin), keyEquivalent: "")
-        launchAtLoginItem.state = launchManager.launchAtLogin ? .on : .off
-        menu.addItem(launchAtLoginItem)
-        
-        menu.addItem(NSMenuItem(title: NSLocalizedString("Settings", comment: ""), action: #selector(showConfigWindow), keyEquivalent: "s"))
-        
-        menu.addItem(NSMenuItem.separator())
-        
-        let versionString = getVersionString()
-        let versionItem = NSMenuItem(title: versionString, action: nil, keyEquivalent: "")
-        versionItem.isEnabled = false
-        menu.addItem(versionItem)
-        
-        menu.addItem(NSMenuItem(title: NSLocalizedString("Quit", comment: ""), action: #selector(quit), keyEquivalent: ""))
-        
-        if oldMenu == nil {
-            NotificationCenter.default.addObserver(self, selector: #selector(updateMenuItems), name: NSNotification.Name("TrackChanged"), object: nil)
-            NotificationCenter.default.addObserver(self, selector: #selector(updateMenuItems), name: NSNotification.Name("PlaybackStateChanged"), object: nil)
-            NotificationCenter.default.addObserver(self, selector: #selector(updateMenuItems), name: NSNotification.Name("PlaylistUpdated"), object: nil)
-        }
-        
-        statusItem?.menu = menu
     }
     
     func setupRemoteCommandCenter() {
@@ -197,98 +99,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @objc func toggleMenu() {
-        updateMenuItems()
-        statusItem?.menu = menu
+        statusMenuController.refresh()
         statusItem?.button?.performClick(nil)
     }
-    
-    @objc func updateMenuItems() {
-        if let trackInfoItem = menu.item(at: 0),
-           let trackLabel = trackInfoItem.view?.subviews.first as? NSTextField {
-            trackLabel.stringValue = playerManager.currentTrack?.title ?? NSLocalizedString("No Music Source", comment: "")
-        }
-        
-        if let playPauseItem = menu.item(at: 2) {
-            playPauseItem.title = playerManager.isPlaying ? NSLocalizedString("Pause", comment: "") : NSLocalizedString("Play", comment: "")
-        }
-        
-        for i in 0..<menu.items.count {
-            let item = menu.item(at: i)
-            if let itemTitle = item?.title, itemTitle == NSLocalizedString("Music Libraries", comment: "Menu item for music libraries") {
-                if let submenu = item?.submenu {
-                    while !submenu.items.isEmpty && submenu.items[0].action != nil && 
-                          submenu.items[0].title != NSLocalizedString("Add New Library", comment: "Menu item for adding a new music library") {
-                        submenu.removeItem(at: 0)
-                    }
-                    
-                    var separatorIndex = -1
-                    for j in 0..<submenu.items.count {
-                        if submenu.items[j].isSeparatorItem {
-                            separatorIndex = j
-                            break
-                        }
-                    }
-                    
-                    for (_, library) in libraryManager.libraries.enumerated().reversed() {
-                        let newItem = NSMenuItem(title: library.name, action: #selector(switchLibrary(_:)), keyEquivalent: "")
-                        newItem.representedObject = library.id
-                        newItem.state = libraryManager.currentLibrary?.id == library.id ? .on : .off
-                        if separatorIndex >= 0 {
-                            submenu.insertItem(newItem, at: 0)
-                        } else {
-                            submenu.addItem(newItem)
-                        }
-                    }
-                    
-                    let refreshItemIndex = submenu.items.firstIndex { $0.title == NSLocalizedString("Refresh Current Library", comment: "Menu item for refreshing current music library") }
-                    if refreshItemIndex == nil && separatorIndex >= 0 {
-                        let refreshItem = NSMenuItem(title: NSLocalizedString("Refresh Current Library", comment: "Menu item for refreshing current music library"), action: #selector(refreshCurrentLibrary), keyEquivalent: "")
-                        submenu.insertItem(refreshItem, at: separatorIndex + 1)
-                    }
-                    
-                    let deleteItemIndex = submenu.items.firstIndex { $0.title == NSLocalizedString("Delete Current Library", comment: "Menu item for deleting current music library") }
-                    if libraryManager.libraries.count > 1 {
-                        if deleteItemIndex == nil {
-                            let renameItemIndex = submenu.items.firstIndex { $0.title == NSLocalizedString("Rename Current Library", comment: "Menu item for renaming current music library") }
-                            if let index = renameItemIndex {
-                                let deleteItem = NSMenuItem(title: NSLocalizedString("Delete Current Library", comment: "Menu item for deleting current music library"), action: #selector(removeCurrentLibrary), keyEquivalent: "")
-                                submenu.insertItem(deleteItem, at: index)
-                            }
-                        }
-                    } else if let index = deleteItemIndex {
-                        submenu.removeItem(at: index)
-                    }
-                }
-                break
-            }
-        }
-        
-        updateStatusBarIcon()
-        updatePlayModeMenuItems()
-    }
-    
-    private func updateStatusBarIcon() {
-        guard let button = statusItem?.button else { return }
-        let symbolName = playerManager.isPlaying ? "headphones.circle.fill" : "headphones.circle"
-        guard let icon = makeStatusBarImage(symbolName: symbolName, accessibilityDescription: "Music") else {
-            button.image = nil
-            return
-        }
 
-        button.image = icon
-        button.imageScaling = .scaleProportionallyDown
-        button.contentTintColor = nil
-    }
-
-    private func makeStatusBarImage(symbolName: String, accessibilityDescription: String) -> NSImage? {
-        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription)?.withSymbolConfiguration(statusBarSymbolConfiguration) else {
-            return nil
-        }
-
-        image.isTemplate = true
-        return image
-    }
-    
     @objc func togglePlayPause() {
         if playerManager.isPlaying {
             playerManager.pause()
@@ -310,11 +124,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     @objc func togglePreventSleep() {
         sleepManager.preventSleep.toggle()
-        if let preventSleepItem = menu.items.first(where: { $0.title == NSLocalizedString("Prevent Mac Sleep", comment: "") }) {
-            preventSleepItem.state = sleepManager.preventSleep ? .on : .off
-        }
+        statusMenuController.refresh()
     }
-    
+
     @objc func setPlayMode(_ sender: NSMenuItem) {
         let mode: PlayMode
         switch sender.tag {
@@ -328,37 +140,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         playerManager.playMode = mode
-        updatePlayModeMenuItems()
+        statusMenuController.refresh()
     }
-    
-    func updatePlayModeMenuItems() {
-        if let playModeItem = menu.items.first(where: { $0.title == NSLocalizedString("Playback Mode", comment: "") }),
-           let playModeMenu = playModeItem.submenu {
-            for item in playModeMenu.items {
-                item.state = item.tag == playerManager.playMode.tag ? .on : .off
-            }
-        }
-    }
-    
+
     @objc func toggleLaunchAtLogin() {
         launchManager.launchAtLogin.toggle()
-        if let launchAtLoginItem = menu.items.first(where: { $0.title == NSLocalizedString("Launch at Login", comment: "") }) {
-            launchAtLoginItem.state = launchManager.launchAtLogin ? .on : .off
-        }
+        statusMenuController.refresh()
     }
     
     func applicationWillTerminate(_ aNotification: Notification) {
         sleepManager.cleanupResourcesOnly()
-    }
-    
-    private func getVersionString() -> String {
-        #if DEBUG
-            let gitCommit = Bundle.main.object(forInfoDictionaryKey: "GitCommit") as? String ?? "unknown"
-            return String(format: NSLocalizedString("Dev: %@", comment: ""), gitCommit)
-        #else
-            let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
-            return String(format: NSLocalizedString("Version %@", comment: ""), appVersion)
-        #endif
     }
     
     @objc func showDownloadWindow() {
@@ -396,8 +187,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         
         libraryManager.addLibrary(name: name, path: path)
-        
-        updateMenuItems()
+
+        statusMenuController.refresh()
     }
     
     @objc func switchLibrary(_ sender: NSMenuItem) {
@@ -408,8 +199,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let currentLibrary = libraryManager.currentLibrary {
             playerManager.loadLibrary(currentLibrary)
         }
-        
-        updateMenuItems()
+
+        statusMenuController.refresh()
     }
     
     @objc func addNewLibrary() {
@@ -435,17 +226,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let newCurrent = libraryManager.currentLibrary {
                 playerManager.loadLibrary(newCurrent)
             }
-            
-            updateMenuItems()
+
+            statusMenuController.refresh()
         }
     }
     
     @objc func refreshCurrentLibrary() {
         guard let currentLibrary = libraryManager.currentLibrary else { return }
-        
+
         // Simply reload the library, same as startup
         playerManager.loadLibrary(currentLibrary)
-        
+
         if let button = statusItem?.button,
            let refreshingIcon = makeStatusBarImage(symbolName: "arrow.clockwise", accessibilityDescription: "Refreshing") {
             button.image = refreshingIcon
@@ -454,8 +245,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.updateStatusBarIcon()
+            self.statusMenuController.refresh()
         }
+    }
+
+    private func makeStatusBarImage(symbolName: String, accessibilityDescription: String) -> NSImage? {
+        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription)?.withSymbolConfiguration(statusBarSymbolConfiguration) else {
+            return nil
+        }
+
+        image.isTemplate = true
+        return image
     }
     
     @objc func renameCurrentLibrary() {
@@ -476,8 +276,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let newName = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
             if !newName.isEmpty {
                 libraryManager.renameLibrary(id: currentLibrary.id, newName: newName)
-                
-                updateMenuItems()
+
+                statusMenuController.refresh()
             }
         }
     }

--- a/MacMusicPlayer/AppDelegate.swift
+++ b/MacMusicPlayer/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         if let statusItem = statusItem {
-            statusMenuController.configureStatusItem(statusItem)
+            statusMenuController.configureStatusItem(statusItem, target: self)
         }
         setupRemoteCommandCenter()
         

--- a/MacMusicPlayer/AppDelegate.swift
+++ b/MacMusicPlayer/AppDelegate.swift
@@ -29,6 +29,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         sleepManager = SleepManager()
         launchManager = LaunchManager()
         libraryManager = LibraryManager()
+        DownloadManager.shared.updateLibraryManager(libraryManager)
         
         if let currentLibrary = libraryManager.currentLibrary {
             playerManager.loadLibrary(currentLibrary)

--- a/MacMusicPlayer/AppDelegate.swift
+++ b/MacMusicPlayer/AppDelegate.swift
@@ -17,8 +17,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var libraryManager: LibraryManager!
     var statusMenuController: StatusMenuController!
 
-    private let statusBarSymbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .medium, scale: .medium)
-    
     // Strong reference to the window
     private var downloadWindow: NSWindow?
     private var configWindow: NSWindow?
@@ -235,28 +233,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func refreshCurrentLibrary() {
         guard let currentLibrary = libraryManager.currentLibrary else { return }
 
-        // Simply reload the library, same as startup
         playerManager.loadLibrary(currentLibrary)
-
-        if let button = statusItem?.button,
-           let refreshingIcon = makeStatusBarImage(symbolName: "arrow.clockwise", accessibilityDescription: "Refreshing") {
-            button.image = refreshingIcon
-            button.contentTintColor = nil
-            button.imageScaling = .scaleProportionallyDown
-        }
+        statusMenuController.showTemporaryRefreshingIcon()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.statusMenuController.refresh()
+            self.statusMenuController.updateStatusBarIcon()
         }
-    }
-
-    private func makeStatusBarImage(symbolName: String, accessibilityDescription: String) -> NSImage? {
-        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription)?.withSymbolConfiguration(statusBarSymbolConfiguration) else {
-            return nil
-        }
-
-        image.isTemplate = true
-        return image
     }
     
     @objc func renameCurrentLibrary() {

--- a/MacMusicPlayer/Controllers/StatusMenuController.swift
+++ b/MacMusicPlayer/Controllers/StatusMenuController.swift
@@ -15,13 +15,10 @@ final class StatusMenuController: NSObject {
     private weak var preventSleepItem: NSMenuItem?
     private weak var launchAtLoginItem: NSMenuItem?
     private weak var playModeMenu: NSMenu?
+    private weak var actionTarget: AppDelegate?
 
     private let statusBarSymbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .medium, scale: .medium)
     private var observersRegistered = false
-
-    private var actionTarget: AnyObject? {
-        NSApp.delegate as AnyObject?
-    }
 
     init(playerManager: PlayerManager,
          sleepManager: SleepManager,
@@ -34,8 +31,9 @@ final class StatusMenuController: NSObject {
         super.init()
     }
 
-    func configureStatusItem(_ statusItem: NSStatusItem) {
+    func configureStatusItem(_ statusItem: NSStatusItem, target: AppDelegate) {
         self.statusItem = statusItem
+        self.actionTarget = target
 
         let menu = NSMenu()
         menu.minimumWidth = 200

--- a/MacMusicPlayer/Controllers/StatusMenuController.swift
+++ b/MacMusicPlayer/Controllers/StatusMenuController.swift
@@ -1,0 +1,281 @@
+import Cocoa
+
+@MainActor
+final class StatusMenuController: NSObject {
+    private let playerManager: PlayerManager
+    private let sleepManager: SleepManager
+    private let launchManager: LaunchManager
+    private let libraryManager: LibraryManager
+
+    private weak var statusItem: NSStatusItem?
+
+    private weak var trackLabel: NSTextField?
+    private weak var playPauseItem: NSMenuItem?
+    private weak var libraryMenu: NSMenu?
+    private weak var preventSleepItem: NSMenuItem?
+    private weak var launchAtLoginItem: NSMenuItem?
+    private weak var playModeMenu: NSMenu?
+
+    private let statusBarSymbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .medium, scale: .medium)
+    private var observersRegistered = false
+
+    private var actionTarget: AnyObject? {
+        NSApp.delegate as AnyObject?
+    }
+
+    init(playerManager: PlayerManager,
+         sleepManager: SleepManager,
+         launchManager: LaunchManager,
+         libraryManager: LibraryManager) {
+        self.playerManager = playerManager
+        self.sleepManager = sleepManager
+        self.launchManager = launchManager
+        self.libraryManager = libraryManager
+        super.init()
+    }
+
+    func configureStatusItem(_ statusItem: NSStatusItem) {
+        self.statusItem = statusItem
+
+        let menu = NSMenu()
+        menu.minimumWidth = 200
+
+        addTrackInfoSection(to: menu)
+        menu.addItem(NSMenuItem.separator())
+        addPlaybackSection(to: menu)
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(makeBrowseItem())
+        menu.addItem(makePlaybackModeSection())
+        menu.addItem(makeLibrarySection())
+        menu.addItem(makeDownloadItem())
+        menu.addItem(makePreventSleepItem())
+        menu.addItem(makeLaunchAtLoginItem())
+        menu.addItem(makeSettingsItem())
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(makeVersionItem())
+        menu.addItem(makeQuitItem())
+
+        statusItem.menu = menu
+        registerNotifications()
+        refresh()
+    }
+
+    @objc
+    func refresh() {
+        updateTrackInfo()
+        updatePlayPauseTitle()
+        rebuildLibraryMenu()
+        updateToggleStates()
+        updateStatusBarIcon()
+        updatePlayModeSelection()
+    }
+
+    private func addTrackInfoSection(to menu: NSMenu) {
+        let trackInfoItem = NSMenuItem(title: NSLocalizedString("No Music Source", comment: ""), action: nil, keyEquivalent: "")
+        trackInfoItem.isEnabled = false
+        let containerView = NSView(frame: NSRect(x: 0, y: 0, width: 180, height: 20))
+        let label = NSTextField(frame: NSRect(x: 10, y: 0, width: 160, height: 20))
+        label.isEditable = false
+        label.isBordered = false
+        label.backgroundColor = .clear
+        label.lineBreakMode = .byTruncatingTail
+        containerView.addSubview(label)
+        trackInfoItem.view = containerView
+        menu.addItem(trackInfoItem)
+        trackLabel = label
+    }
+
+    private func addPlaybackSection(to menu: NSMenu) {
+        let playPauseTitle = playerManager.isPlaying ? NSLocalizedString("Pause", comment: "") : NSLocalizedString("Play", comment: "")
+        let playPauseItem = NSMenuItem(title: playPauseTitle, action: #selector(AppDelegate.togglePlayPause), keyEquivalent: "")
+        playPauseItem.target = actionTarget
+        menu.addItem(playPauseItem)
+        self.playPauseItem = playPauseItem
+
+        let previousItem = NSMenuItem(title: NSLocalizedString("Previous", comment: ""), action: #selector(AppDelegate.playPrevious), keyEquivalent: "")
+        previousItem.target = actionTarget
+        menu.addItem(previousItem)
+
+        let nextItem = NSMenuItem(title: NSLocalizedString("Next", comment: ""), action: #selector(AppDelegate.playNext), keyEquivalent: "")
+        nextItem.target = actionTarget
+        menu.addItem(nextItem)
+    }
+
+    private func makeBrowseItem() -> NSMenuItem {
+        let item = NSMenuItem(title: NSLocalizedString("Browse Songs", comment: "Menu item for browsing and selecting songs"), action: #selector(AppDelegate.showSongPickerWindow), keyEquivalent: "f")
+        item.target = actionTarget
+        return item
+    }
+
+    private func makePlaybackModeSection() -> NSMenuItem {
+        let playModeMenu = NSMenu()
+        let playModeItem = NSMenuItem(title: NSLocalizedString("Playback Mode", comment: ""), action: nil, keyEquivalent: "")
+
+        let sequentialItem = NSMenuItem(title: PlayMode.sequential.localizedString, action: #selector(AppDelegate.setPlayMode(_:)), keyEquivalent: "")
+        sequentialItem.tag = 0
+        sequentialItem.target = actionTarget
+
+        let singleLoopItem = NSMenuItem(title: PlayMode.singleLoop.localizedString, action: #selector(AppDelegate.setPlayMode(_:)), keyEquivalent: "")
+        singleLoopItem.tag = 1
+        singleLoopItem.target = actionTarget
+
+        let randomItem = NSMenuItem(title: PlayMode.random.localizedString, action: #selector(AppDelegate.setPlayMode(_:)), keyEquivalent: "")
+        randomItem.tag = 2
+        randomItem.target = actionTarget
+
+        playModeMenu.addItem(sequentialItem)
+        playModeMenu.addItem(singleLoopItem)
+        playModeMenu.addItem(randomItem)
+
+        playModeItem.submenu = playModeMenu
+        self.playModeMenu = playModeMenu
+
+        return playModeItem
+    }
+
+    private func makeLibrarySection() -> NSMenuItem {
+        let libraryMenu = NSMenu()
+        let libraryMenuItem = NSMenuItem(title: NSLocalizedString("Music Libraries", comment: "Menu item for music libraries"), action: nil, keyEquivalent: "")
+        libraryMenuItem.submenu = libraryMenu
+        self.libraryMenu = libraryMenu
+        rebuildLibraryMenu()
+        return libraryMenuItem
+    }
+
+    private func makeDownloadItem() -> NSMenuItem {
+        let item = NSMenuItem(title: NSLocalizedString("Download Music", comment: ""), action: #selector(AppDelegate.showDownloadWindow), keyEquivalent: "d")
+        item.target = actionTarget
+        return item
+    }
+
+    private func makePreventSleepItem() -> NSMenuItem {
+        let item = NSMenuItem(title: NSLocalizedString("Prevent Mac Sleep", comment: ""), action: #selector(AppDelegate.togglePreventSleep), keyEquivalent: "")
+        item.target = actionTarget
+        item.state = sleepManager.preventSleep ? .on : .off
+        preventSleepItem = item
+        return item
+    }
+
+    private func makeLaunchAtLoginItem() -> NSMenuItem {
+        let item = NSMenuItem(title: NSLocalizedString("Launch at Login", comment: ""), action: #selector(AppDelegate.toggleLaunchAtLogin), keyEquivalent: "")
+        item.target = actionTarget
+        item.state = launchManager.launchAtLogin ? .on : .off
+        launchAtLoginItem = item
+        return item
+    }
+
+    private func makeSettingsItem() -> NSMenuItem {
+        let item = NSMenuItem(title: NSLocalizedString("Settings", comment: ""), action: #selector(AppDelegate.showConfigWindow), keyEquivalent: "s")
+        item.target = actionTarget
+        return item
+    }
+
+    private func makeVersionItem() -> NSMenuItem {
+        let versionItem = NSMenuItem(title: getVersionString(), action: nil, keyEquivalent: "")
+        versionItem.isEnabled = false
+        return versionItem
+    }
+
+    private func makeQuitItem() -> NSMenuItem {
+        let item = NSMenuItem(title: NSLocalizedString("Quit", comment: ""), action: #selector(AppDelegate.quit), keyEquivalent: "")
+        item.target = actionTarget
+        return item
+    }
+
+    private func updateTrackInfo() {
+        trackLabel?.stringValue = playerManager.currentTrack?.title ?? NSLocalizedString("No Music Source", comment: "")
+    }
+
+    private func updatePlayPauseTitle() {
+        playPauseItem?.title = playerManager.isPlaying ? NSLocalizedString("Pause", comment: "") : NSLocalizedString("Play", comment: "")
+    }
+
+    private func rebuildLibraryMenu() {
+        guard let libraryMenu = libraryMenu else { return }
+        libraryMenu.removeAllItems()
+
+        for library in libraryManager.libraries {
+            let item = NSMenuItem(title: library.name, action: #selector(AppDelegate.switchLibrary(_:)), keyEquivalent: "")
+            item.representedObject = library.id
+            item.state = libraryManager.currentLibrary?.id == library.id ? .on : .off
+            item.target = actionTarget
+            libraryMenu.addItem(item)
+        }
+
+        libraryMenu.addItem(NSMenuItem.separator())
+
+        let refreshItem = NSMenuItem(title: NSLocalizedString("Refresh Current Library", comment: "Menu item for refreshing current music library"), action: #selector(AppDelegate.refreshCurrentLibrary), keyEquivalent: "r")
+        refreshItem.target = actionTarget
+        libraryMenu.addItem(refreshItem)
+
+        let addItem = NSMenuItem(title: NSLocalizedString("Add New Library", comment: "Menu item for adding a new music library"), action: #selector(AppDelegate.addNewLibrary), keyEquivalent: "")
+        addItem.target = actionTarget
+        libraryMenu.addItem(addItem)
+
+        if libraryManager.libraries.count > 1 {
+            let deleteItem = NSMenuItem(title: NSLocalizedString("Delete Current Library", comment: "Menu item for deleting current music library"), action: #selector(AppDelegate.removeCurrentLibrary), keyEquivalent: "")
+            deleteItem.target = actionTarget
+            libraryMenu.addItem(deleteItem)
+        }
+
+        let renameItem = NSMenuItem(title: NSLocalizedString("Rename Current Library", comment: "Menu item for renaming current music library"), action: #selector(AppDelegate.renameCurrentLibrary), keyEquivalent: "")
+        renameItem.target = actionTarget
+        libraryMenu.addItem(renameItem)
+    }
+
+    private func updateToggleStates() {
+        preventSleepItem?.state = sleepManager.preventSleep ? .on : .off
+        launchAtLoginItem?.state = launchManager.launchAtLogin ? .on : .off
+    }
+
+    private func updateStatusBarIcon() {
+        guard let button = statusItem?.button else { return }
+        let symbolName = playerManager.isPlaying ? "headphones.circle.fill" : "headphones.circle"
+        guard let icon = makeStatusBarImage(symbolName: symbolName, accessibilityDescription: "Music") else {
+            button.image = nil
+            return
+        }
+
+        button.image = icon
+        button.imageScaling = .scaleProportionallyDown
+        button.contentTintColor = nil
+    }
+
+    private func updatePlayModeSelection() {
+        guard let playModeMenu = playModeMenu else { return }
+        for item in playModeMenu.items {
+            item.state = item.tag == playerManager.playMode.tag ? .on : .off
+        }
+    }
+
+    private func makeStatusBarImage(symbolName: String, accessibilityDescription: String) -> NSImage? {
+        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription)?.withSymbolConfiguration(statusBarSymbolConfiguration) else {
+            return nil
+        }
+
+        image.isTemplate = true
+        return image
+    }
+
+    private func registerNotifications() {
+        guard !observersRegistered else { return }
+        NotificationCenter.default.addObserver(self, selector: #selector(refresh), name: NSNotification.Name("TrackChanged"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refresh), name: NSNotification.Name("PlaybackStateChanged"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refresh), name: NSNotification.Name("PlaylistUpdated"), object: nil)
+        observersRegistered = true
+    }
+
+    private func getVersionString() -> String {
+        #if DEBUG
+            let gitCommit = Bundle.main.object(forInfoDictionaryKey: "GitCommit") as? String ?? "unknown"
+            return String(format: NSLocalizedString("Dev: %@", comment: ""), gitCommit)
+        #else
+            let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+            return String(format: NSLocalizedString("Version %@", comment: ""), appVersion)
+        #endif
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/MacMusicPlayer/Controllers/StatusMenuController.swift
+++ b/MacMusicPlayer/Controllers/StatusMenuController.swift
@@ -226,11 +226,22 @@ final class StatusMenuController: NSObject {
         launchAtLoginItem?.state = launchManager.launchAtLogin ? .on : .off
     }
 
-    private func updateStatusBarIcon() {
+    func updateStatusBarIcon() {
         guard let button = statusItem?.button else { return }
         let symbolName = playerManager.isPlaying ? "headphones.circle.fill" : "headphones.circle"
         guard let icon = makeStatusBarImage(symbolName: symbolName, accessibilityDescription: "Music") else {
             button.image = nil
+            return
+        }
+
+        button.image = icon
+        button.imageScaling = .scaleProportionallyDown
+        button.contentTintColor = nil
+    }
+
+    func showTemporaryRefreshingIcon() {
+        guard let button = statusItem?.button else { return }
+        guard let icon = makeStatusBarImage(symbolName: "arrow.clockwise", accessibilityDescription: "Refreshing") else {
             return
         }
 

--- a/MacMusicPlayer/Controllers/StatusMenuController.swift
+++ b/MacMusicPlayer/Controllers/StatusMenuController.swift
@@ -136,7 +136,6 @@ final class StatusMenuController: NSObject {
         let libraryMenuItem = NSMenuItem(title: NSLocalizedString("Music Libraries", comment: "Menu item for music libraries"), action: nil, keyEquivalent: "")
         libraryMenuItem.submenu = libraryMenu
         self.libraryMenu = libraryMenu
-        rebuildLibraryMenu()
         return libraryMenuItem
     }
 

--- a/MacMusicPlayer/Managers/DownloadManager.swift
+++ b/MacMusicPlayer/Managers/DownloadManager.swift
@@ -10,17 +10,17 @@ import AppKit
 
 public class DownloadManager {
     public static let shared = DownloadManager()
-    
+
     private var libraryManager: LibraryManager
-    
+
     private init() {
-        // Use shared LibraryManager instance to keep in sync with UI
-        if let appDelegate = NSApp.delegate as? AppDelegate {
-            self.libraryManager = appDelegate.libraryManager
-        } else {
-            // Fallback: create new instance
-            self.libraryManager = LibraryManager()
-        }
+        // Default to a standalone LibraryManager until the app delegate binds the shared instance.
+        self.libraryManager = LibraryManager()
+    }
+
+    @MainActor
+    func updateLibraryManager(_ libraryManager: LibraryManager) {
+        self.libraryManager = libraryManager
     }
     
     public struct DownloadFormat {

--- a/MacMusicPlayer/Managers/PlayerManager.swift
+++ b/MacMusicPlayer/Managers/PlayerManager.swift
@@ -345,6 +345,7 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
 
+    @MainActor
     @objc func refreshMusicLibrary() {
         // Simply reload the current library, same as startup
         if let library = (NSApplication.shared.delegate as? AppDelegate)?.libraryManager.currentLibrary {


### PR DESCRIPTION
## Summary
- mark AppDelegate and StatusMenuController as @MainActor to ensure status bar interactions stay on the main thread
- ensure all status menu items explicitly target the application delegate so their actions continue to fire after the refactor

## Testing
- make dmg *(fails: xcodebuild not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d4fd509e8833081038c7dec478f24)