### PR TITLE
[Chore] Remove source code comments

### DIFF
--- a/MacMusicPlayer/AppDelegate.swift
+++ b/MacMusicPlayer/AppDelegate.swift
@@ -1,13 +1,6 @@
-//
-//  AppDelegate.swift
-//  MacMusicPlayer
-//
-//  Created by samzong<samzong.lu@gmail.com> on 2024/09/18.
-//
-
 import Cocoa
 import MediaPlayer
- 
+
 
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -19,11 +12,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var configManager: ConfigManager!
     var statusMenuController: StatusMenuController!
 
-    // Strong reference to the window
     private var downloadWindow: NSWindow?
     private var configWindow: NSWindow?
     private var songPickerWindow: SimpleSongPickerWindow?
-    
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         playerManager = PlayerManager()
         sleepManager = SleepManager()
@@ -31,15 +23,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         libraryManager = LibraryManager()
         configManager = ConfigManager.shared
         DownloadManager.shared.updateLibraryManager(libraryManager)
-        
+
         if let currentLibrary = libraryManager.currentLibrary {
             playerManager.loadLibrary(currentLibrary)
         } else {
             playerManager.requestMusicFolderAccess()
         }
-        
+
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        
+
         if let button = statusItem?.button {
             button.target = self
             button.action = #selector(toggleMenu)
@@ -56,32 +48,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             statusMenuController.configureStatusItem(statusItem, target: self)
         }
         setupRemoteCommandCenter()
-        
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAddNewLibrary(_:)),
             name: NSNotification.Name("AddNewLibrary"),
             object: nil
         )
-        
+
         DispatchQueue.main.async { [weak self] in
             self?.showSongPickerIfPreferred()
         }
     }
-    
+
     func setupRemoteCommandCenter() {
         let commandCenter = MPRemoteCommandCenter.shared()
-        
+
         commandCenter.playCommand.addTarget { [weak self] _ in
             self?.playerManager.play()
             return .success
         }
-        
+
         commandCenter.pauseCommand.addTarget { [weak self] _ in
             self?.playerManager.pause()
             return .success
         }
-        
+
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
             if let isPlaying = self?.playerManager.isPlaying {
                 if isPlaying {
@@ -92,18 +84,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             return .success
         }
-        
+
         commandCenter.nextTrackCommand.addTarget { [weak self] _ in
             self?.playerManager.playNext()
             return .success
         }
-        
+
         commandCenter.previousTrackCommand.addTarget { [weak self] _ in
             self?.playerManager.playPrevious()
             return .success
         }
     }
-    
+
     @objc func toggleMenu() {
         statusMenuController.refresh()
         statusItem?.button?.performClick(nil)
@@ -116,11 +108,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             playerManager.play()
         }
     }
-    
+
     @objc func playPrevious() {
         playerManager.playPrevious()
     }
-    
+
     @objc func playNext() {
         playerManager.playNext()
     }
@@ -128,7 +120,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func feelingLucky() {
         playerManager.feelingLucky()
     }
-    
+
     @objc func quit() {
         NSApplication.shared.terminate(self)
     }
@@ -157,23 +149,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         launchManager.launchAtLogin.toggle()
         statusMenuController.refresh()
     }
-    
+
     func applicationWillTerminate(_ aNotification: Notification) {
         sleepManager.cleanupResourcesOnly()
     }
-    
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         showSongPickerIfPreferred()
         return true
     }
-    
+
     @objc func showDownloadWindow() {
         if let existingWindow = self.downloadWindow {
             existingWindow.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
-        
+
         let downloadVC = DownloadViewController()
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 400),
@@ -184,60 +176,60 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.contentViewController = downloadVC
         window.title = NSLocalizedString("Download Music", comment: "")
         window.center()
-        
+
         window.isReleasedWhenClosed = false
         window.delegate = self
-        
+
         self.downloadWindow = window
-        
+
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
-    
+
     @objc func handleAddNewLibrary(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
               let name = userInfo["name"] as? String,
               let path = userInfo["path"] as? String else {
             return
         }
-        
+
         libraryManager.addLibrary(name: name, path: path)
 
         statusMenuController.refresh()
     }
-    
+
     @objc func switchLibrary(_ sender: NSMenuItem) {
         guard let libraryId = sender.representedObject as? UUID else { return }
-        
+
         libraryManager.switchLibrary(id: libraryId)
-        
+
         if let currentLibrary = libraryManager.currentLibrary {
             playerManager.loadLibrary(currentLibrary)
         }
 
         statusMenuController.refresh()
     }
-    
+
     @objc func addNewLibrary() {
         playerManager.requestMusicFolderAccess()
     }
-    
+
     @objc func removeCurrentLibrary() {
         guard libraryManager.libraries.count > 1,
               let currentId = libraryManager.currentLibrary?.id else {
             return
         }
-        
+
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Confirm Deletion", comment: "Alert title when deleting a music library")
         alert.informativeText = NSLocalizedString("This operation will not delete music files on disk, it only removes this library from the app.", comment: "Alert description when deleting a music library")
         alert.alertStyle = .warning
         alert.addButton(withTitle: NSLocalizedString("Delete", comment: "Button title for confirming deletion"))
         alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Button title for cancelling deletion"))
-        
+
         if alert.runModal() == .alertFirstButtonReturn {
             libraryManager.removeLibrary(id: currentId)
-            
+
             if let newCurrent = libraryManager.currentLibrary {
                 playerManager.loadLibrary(newCurrent)
             }
@@ -245,7 +237,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             statusMenuController.refresh()
         }
     }
-    
+
     @objc func refreshCurrentLibrary() {
         guard let currentLibrary = libraryManager.currentLibrary else { return }
 
@@ -256,21 +248,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self.statusMenuController.updateStatusBarIcon()
         }
     }
-    
+
     @objc func renameCurrentLibrary() {
         guard let currentLibrary = libraryManager.currentLibrary else { return }
-        
+
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Rename Library", comment: "Alert title when renaming a music library")
         alert.informativeText = NSLocalizedString("Please enter a new name for the library:", comment: "Alert description when renaming a music library")
         alert.alertStyle = .informational
         alert.addButton(withTitle: NSLocalizedString("OK", comment: "Button title for confirming rename"))
         alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Button title for cancelling rename"))
-        
+
         let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
         textField.stringValue = currentLibrary.name
         alert.accessoryView = textField
-        
+
         if alert.runModal() == .alertFirstButtonReturn {
             let newName = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
             if !newName.isEmpty {
@@ -280,7 +272,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
-    
+
     @objc func showConfigWindow() {
         if let existingWindow = self.configWindow {
             existingWindow.makeKeyAndOrderFront(nil)
@@ -326,13 +318,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         songPickerWindow.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
-    
+
     private func showSongPickerIfPreferred() {
         guard configManager.showSongPickerOnLaunch else { return }
         showSongPickerWindow()
     }
-    
-    
+
+
 }
 
 extension AppDelegate: NSWindowDelegate {

--- a/MacMusicPlayer/Controllers/ConfigViewController.swift
+++ b/MacMusicPlayer/Controllers/ConfigViewController.swift
@@ -1,15 +1,7 @@
-//
-//  ConfigViewController.swift
-//  MacMusicPlayer
-//
-//  Created by samzong<samzong.lu@gmail.com>
-//
-
 import Cocoa
 
 class ConfigViewController: NSViewController {
-    // MARK: - UI Components
-    
+
     private let apiUrlLabel = NSTextField()
     private let apiUrlTextField = NSTextField()
     private let apiKeyLabel = NSTextField()
@@ -21,40 +13,36 @@ class ConfigViewController: NSViewController {
     private let songPickerCheckbox = NSButton()
     private var statusStackView: NSStackView?
     private var hideStatusWorkItem: DispatchWorkItem?
-    
-    // MARK: - Properties
+
     private let configManager = ConfigManager.shared
     private var saveCallback: (() -> Void)?
-    
-    // MARK: - Initialization
+
     init(saveCallback: (() -> Void)? = nil) {
         self.saveCallback = saveCallback
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - Lifecycle
+
     override func loadView() {
         self.view = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 280))
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
     }
-    
+
     override func viewWillAppear() {
         super.viewWillAppear()
         loadCurrentConfig()
     }
-    
-    // MARK: - UI Setup
+
     private func setupUI() {
         view.wantsLayer = true
-        
+
         setupApiKeyUI()
         setupApiUrlUI()
         setupSongPickerPreference()
@@ -62,7 +50,7 @@ class ConfigViewController: NSViewController {
         setupFormGrid()
         setupButtons()
     }
-    
+
     private func setupApiKeyUI() {
         apiKeyLabel.translatesAutoresizingMaskIntoConstraints = false
         apiKeyLabel.stringValue = NSLocalizedString("API Key:", comment: "API Key label")
@@ -72,14 +60,14 @@ class ConfigViewController: NSViewController {
         apiKeyLabel.alignment = .right
         apiKeyLabel.font = NSFont.systemFont(ofSize: 13)
         apiKeyLabel.textColor = NSColor.labelColor
-        
+
         apiKeyTextField.translatesAutoresizingMaskIntoConstraints = false
         apiKeyTextField.placeholderString = NSLocalizedString("Enter API Key", comment: "API Key placeholder")
         apiKeyTextField.font = NSFont.systemFont(ofSize: 13)
         apiKeyTextField.bezelStyle = .roundedBezel
         apiKeyTextField.focusRingType = .exterior
     }
-    
+
     private func setupApiUrlUI() {
         apiUrlLabel.translatesAutoresizingMaskIntoConstraints = false
         apiUrlLabel.stringValue = NSLocalizedString("API URL:", comment: "API URL label")
@@ -89,14 +77,14 @@ class ConfigViewController: NSViewController {
         apiUrlLabel.alignment = .right
         apiUrlLabel.font = NSFont.systemFont(ofSize: 13)
         apiUrlLabel.textColor = NSColor.labelColor
-        
+
         apiUrlTextField.translatesAutoresizingMaskIntoConstraints = false
         apiUrlTextField.placeholderString = NSLocalizedString("Enter API URL", comment: "API URL placeholder")
         apiUrlTextField.font = NSFont.systemFont(ofSize: 13)
         apiUrlTextField.bezelStyle = .roundedBezel
         apiUrlTextField.focusRingType = .exterior
     }
-    
+
     private func setupButtons() {
         saveButton.translatesAutoresizingMaskIntoConstraints = false
         saveButton.title = NSLocalizedString("Save", comment: "Save button")
@@ -125,9 +113,8 @@ class ConfigViewController: NSViewController {
             buttonStack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -20)
         ])
     }
-    
-    
-    
+
+
     private func setupStatusLabel() {
         statusIconView.translatesAutoresizingMaskIntoConstraints = false
         statusIconView.isHidden = true
@@ -137,7 +124,7 @@ class ConfigViewController: NSViewController {
         statusIconView.contentTintColor = NSColor.systemGreen
         statusIconView.setContentCompressionResistancePriority(.required, for: .horizontal)
         statusIconView.setContentHuggingPriority(.required, for: .horizontal)
-        
+
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         statusLabel.stringValue = ""
         statusLabel.isEditable = false
@@ -148,7 +135,7 @@ class ConfigViewController: NSViewController {
         statusLabel.textColor = NSColor.secondaryLabelColor
         statusLabel.isHidden = true
         statusLabel.lineBreakMode = .byWordWrapping
-        
+
         let stackView = NSStackView()
         stackView.orientation = .horizontal
         stackView.alignment = .centerY
@@ -195,7 +182,7 @@ class ConfigViewController: NSViewController {
             grid.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
         ])
     }
-    
+
     private func setupSongPickerPreference() {
         songPickerCheckbox.translatesAutoresizingMaskIntoConstraints = false
         songPickerCheckbox.setButtonType(.switch)
@@ -203,14 +190,13 @@ class ConfigViewController: NSViewController {
         songPickerCheckbox.font = NSFont.systemFont(ofSize: 13)
         songPickerCheckbox.state = configManager.showSongPickerOnLaunch ? .on : .off
     }
-    
-    // MARK: - Functionality
+
     private func loadCurrentConfig() {
         apiKeyTextField.stringValue = configManager.apiKey
         apiUrlTextField.stringValue = configManager.apiUrl
         songPickerCheckbox.state = configManager.showSongPickerOnLaunch ? .on : .off
     }
-    
+
     @objc private func saveConfig() {
         let apiKey = apiKeyTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         var apiUrl = apiUrlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -218,55 +204,50 @@ class ConfigViewController: NSViewController {
         let currentApiUrl = configManager.apiUrl
         let apiKeyChanged = apiKey != currentApiKey
         let apiUrlChanged = apiUrl != currentApiUrl
-        
-        // Ensure URL format is correct
+
         if !apiUrl.isEmpty && !apiUrl.hasPrefix("http") {
             apiUrl = "https://" + apiUrl
         }
-        // Validate URL format
         if apiUrlChanged && !apiUrl.isEmpty {
             if URLComponents(string: apiUrl) == nil {
                 showStatus(NSLocalizedString("API URL is invalid", comment: "Error message when API URL is invalid"), isError: true)
                 return
             }
         }
-        
-        // Validate input
+
         if apiKeyChanged && apiKey.isEmpty {
             showStatus(NSLocalizedString("Please enter API Key", comment: "Error message when API Key is empty"), isError: true)
             return
         }
-        
+
         if apiUrlChanged && apiUrl.isEmpty {
             showStatus(NSLocalizedString("Please enter API URL", comment: "Error message when API URL is empty"), isError: true)
             return
         }
-        
-        // Save configuration
+
         let shouldShowSongPicker = (songPickerCheckbox.state == .on)
-        
+
         configManager.saveConfig(apiKey: apiKey, apiUrl: apiUrl, showSongPickerOnLaunch: shouldShowSongPicker)
         showStatus(NSLocalizedString("Configuration saved", comment: "Success message when configuration is saved"), isError: false)
-        
-        // Call callback function
+
         saveCallback?()
     }
-    
+
     @objc private func cancelConfig() {
         configManager.resetConfig()
         loadCurrentConfig()
         showStatus(NSLocalizedString("Reset to defaults", comment: "Success message when configuration is reset"), isError: false)
     }
-    
-    
+
+
     private func showStatus(_ message: String, isError: Bool) {
         hideStatusWorkItem?.cancel()
-        
+
         let textColor: NSColor = isError ? .systemRed : .systemGreen
         statusLabel.stringValue = message
         statusLabel.textColor = textColor
         statusLabel.isHidden = false
-        
+
         if #available(macOS 11.0, *) {
             let symbolName = isError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
             statusIconView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
@@ -275,7 +256,7 @@ class ConfigViewController: NSViewController {
         }
         statusIconView.contentTintColor = textColor
         statusIconView.isHidden = false
-        
+
         if let stack = statusStackView {
             stack.isHidden = false
             NSAnimationContext.runAnimationGroup { context in
@@ -283,7 +264,7 @@ class ConfigViewController: NSViewController {
                 stack.animator().alphaValue = 1
             }
         }
-        
+
         if !isError {
             let workItem = DispatchWorkItem { [weak self] in
                 guard let self = self, let stack = self.statusStackView else { return }

--- a/MacMusicPlayer/Controllers/DownloadViewController.swift
+++ b/MacMusicPlayer/Controllers/DownloadViewController.swift
@@ -1,14 +1,7 @@
-//
-//  DownloadViewController.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
 import Cocoa
 import AppKit
 
 class DownloadViewController: NSViewController {
-    // MARK: - UI Components
     private let urlTextField = NSTextField()
     private let detectButton = NSButton()
     private let statusLabel = NSTextField()
@@ -20,12 +13,10 @@ class DownloadViewController: NSViewController {
     private let tableBackgroundView = NSVisualEffectView()
     private let libraryPopup = NSPopUpButton()
     private let libraryLabel = NSTextField()
-    
-    // Pagination buttons
+
     private let nextPageButton = NSButton()
     private let downloadAllButton = NSButton()
-    
-    // MARK: - Properties
+
     private var formats: [DownloadManager.DownloadFormat] = []
     private var ytDlpVersion: String = ""
     private var ffmpegVersion: String = ""
@@ -41,63 +32,53 @@ class DownloadViewController: NSViewController {
         var ffmpegVersion: String
     }
     private var libraryManager: LibraryManager!
-    
-    // Playlist-related properties
+
     private var currentPlaylist: DownloadManager.PlaylistInfo?
     private var isPlaylistMode: Bool = false
     private var isDownloading: Bool = false
     private var downloadTask: Task<Void, Never>?
     private weak var activeDownloadButton: NSButton?
-    
-    // Search-related properties
+
     private var searchResults: [YTSearchManager.SearchResult.VideoItem] = []
     private var isSearchMode: Bool = false
     private var currentNextPageToken: String? = nil
-    private var lastSearchKeyword: String = ""  // Save last search keyword
+    private var lastSearchKeyword: String = ""
     private let ytSearchManager = YTSearchManager.shared
     private let configManager = ConfigManager.shared
-    
-    // UI-related constraints
+
     private var nextPageButtonLeadingConstraint: NSLayoutConstraint?
-    
-    // Track which video row is expanded
+
     private var expandedVideoRow: Int? = nil
     private var formatOptions: [FormatOption] = []
-    
-    // Format option structure
+
     struct FormatOption {
         let title: String
         let formatId: String
         let videoItem: YTSearchManager.SearchResult.VideoItem
     }
-    
-    // MARK: - Lifecycle
+
     override func loadView() {
-        // Set an appropriate initial size, consistent with the compact height used later
         self.view = NSView(frame: NSRect(x: 0, y: 0, width: 600, height: 140))
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Use shared LibraryManager instance
+
         if let appDelegate = NSApp.delegate as? AppDelegate {
             libraryManager = appDelegate.libraryManager
         } else {
             libraryManager = LibraryManager()
         }
-        
+
         setupUI()
-        
-        // Add text field change event listener
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(textFieldDidChange(_:)),
             name: NSControl.textDidChangeNotification,
             object: urlTextField
         )
-        
-        // Add configuration update notification listener
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleConfigUpdated),
@@ -105,33 +86,30 @@ class DownloadViewController: NSViewController {
             object: nil
         )
     }
-    
+
     override func viewDidAppear() {
         super.viewDidAppear()
-        
-        // Ensure window becomes the focus window
+
         if let window = view.window {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
-            
-            // Set focus to URL input field
+
             self.view.window?.makeFirstResponder(urlTextField)
         }
-        
+
         updateLibraryPopup()
         scheduleDependencyCheckIfNeeded()
     }
-    
-    // MARK: - UI Setup
+
     private func setupUI() {
         view.wantsLayer = true
-        
+
         if let window = view.window {
             window.title = NSLocalizedString("Download Music", comment: "")
             window.titleVisibility = .visible
             window.titlebarAppearsTransparent = false
         }
-        
+
         setupLibrarySelector()
         setupURLField()
         setupDetectButton()
@@ -143,7 +121,7 @@ class DownloadViewController: NSViewController {
         setupNextPageButton()
         setupDownloadAllButton()
     }
-    
+
     private func setupURLField() {
         urlTextField.translatesAutoresizingMaskIntoConstraints = false
         urlTextField.placeholderString = NSLocalizedString("Enter video URL or search keyword", comment: "")
@@ -153,7 +131,7 @@ class DownloadViewController: NSViewController {
         urlTextField.target = self
         urlTextField.action = #selector(detectOrSearch)
         view.addSubview(urlTextField)
-        
+
         NSLayoutConstraint.activate([
             urlTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             urlTextField.leadingAnchor.constraint(equalTo: libraryPopup.trailingAnchor, constant: 8),
@@ -161,25 +139,25 @@ class DownloadViewController: NSViewController {
             urlTextField.heightAnchor.constraint(equalToConstant: 28)
         ])
     }
-    
+
     private func setupDetectButton() {
         detectButton.translatesAutoresizingMaskIntoConstraints = false
-        detectButton.title = NSLocalizedString("Search", comment: "") // default is "Search"
+        detectButton.title = NSLocalizedString("Search", comment: "")
         detectButton.bezelStyle = .rounded
         detectButton.target = self
         detectButton.action = #selector(detectOrSearch)
         detectButton.font = NSFont.systemFont(ofSize: 13, weight: .medium)
         detectButton.contentTintColor = .white
         detectButton.wantsLayer = true
-        
+
         if #available(macOS 11.0, *) {
             detectButton.bezelColor = NSColor.controlAccentColor
         } else {
             detectButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
         }
-        
+
         view.addSubview(detectButton)
-        
+
         NSLayoutConstraint.activate([
             detectButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             detectButton.leadingAnchor.constraint(equalTo: urlTextField.trailingAnchor, constant: 8),
@@ -187,7 +165,7 @@ class DownloadViewController: NSViewController {
             detectButton.heightAnchor.constraint(equalToConstant: 28)
         ])
     }
-    
+
     private func setupNextPageButton() {
         nextPageButton.translatesAutoresizingMaskIntoConstraints = false
         nextPageButton.title = NSLocalizedString("View more", comment: "")
@@ -197,9 +175,8 @@ class DownloadViewController: NSViewController {
         nextPageButton.action = #selector(loadNextPage)
         nextPageButton.font = NSFont.systemFont(ofSize: 12)
         nextPageButton.contentTintColor = NSColor.linkColor
-        nextPageButton.isHidden = true // Hide initially
-        
-        // Add mouse hover effect
+        nextPageButton.isHidden = true
+
         let trackingArea = NSTrackingArea(
             rect: NSRect.zero,
             options: [.inVisibleRect, .activeAlways, .mouseEnteredAndExited],
@@ -207,19 +184,18 @@ class DownloadViewController: NSViewController {
             userInfo: ["button": "nextPage"]
         )
         nextPageButton.addTrackingArea(trackingArea)
-        
+
         view.addSubview(nextPageButton)
-        
-        // Right-align, no longer using position relative to statusLabel
+
         nextPageButtonLeadingConstraint = nil
-        
+
         NSLayoutConstraint.activate([
             nextPageButton.centerYAnchor.constraint(equalTo: statusLabel.centerYAnchor),
             nextPageButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             nextPageButton.heightAnchor.constraint(equalToConstant: 16)
         ])
     }
-    
+
     private func setupDownloadAllButton() {
         downloadAllButton.translatesAutoresizingMaskIntoConstraints = false
         downloadAllButton.title = NSLocalizedString("Download All", comment: "")
@@ -228,16 +204,16 @@ class DownloadViewController: NSViewController {
         downloadAllButton.target = self
         downloadAllButton.action = #selector(downloadAllButtonTapped)
         downloadAllButton.contentTintColor = NSColor.white
-        downloadAllButton.isHidden = true // Hide initially
-        
+        downloadAllButton.isHidden = true
+
         if #available(macOS 11.0, *) {
             downloadAllButton.bezelColor = NSColor.controlAccentColor
         } else {
             downloadAllButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
         }
-        
+
         view.addSubview(downloadAllButton)
-        
+
         NSLayoutConstraint.activate([
             downloadAllButton.centerYAnchor.constraint(equalTo: statusLabel.centerYAnchor),
             downloadAllButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
@@ -245,7 +221,7 @@ class DownloadViewController: NSViewController {
             downloadAllButton.widthAnchor.constraint(equalToConstant: 100)
         ])
     }
-    
+
     private func setupLibrarySelector() {
         libraryLabel.translatesAutoresizingMaskIntoConstraints = false
         libraryLabel.isEditable = false
@@ -257,47 +233,47 @@ class DownloadViewController: NSViewController {
         libraryLabel.stringValue = ""
         libraryLabel.isHidden = true
         view.addSubview(libraryLabel)
-        
+
         libraryPopup.translatesAutoresizingMaskIntoConstraints = false
         libraryPopup.target = self
         libraryPopup.action = #selector(handleLibrarySelection(_:))
         view.addSubview(libraryPopup)
-        
+
         NSLayoutConstraint.activate([
             libraryLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             libraryLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             libraryLabel.heightAnchor.constraint(equalToConstant: 28),
-            
+
             libraryPopup.centerYAnchor.constraint(equalTo: libraryLabel.centerYAnchor),
             libraryPopup.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             libraryPopup.widthAnchor.constraint(equalToConstant: 120),
             libraryPopup.heightAnchor.constraint(equalToConstant: 28)
         ])
-        
+
         updateLibraryPopup()
     }
-    
+
     private func updateLibraryPopup() {
         libraryPopup.removeAllItems()
-        
+
         for library in libraryManager.libraries {
             libraryPopup.addItem(withTitle: library.name)
         }
-        
+
         if let currentLibrary = libraryManager.currentLibrary,
            let index = libraryManager.libraries.firstIndex(where: { $0.id == currentLibrary.id }) {
             libraryPopup.selectItem(at: index)
         }
     }
-    
+
     @objc private func handleLibrarySelection(_ sender: NSPopUpButton) {
         let selectedIndex = sender.indexOfSelectedItem
         guard selectedIndex >= 0 && selectedIndex < libraryManager.libraries.count else { return }
-        
+
         let selectedLibrary = libraryManager.libraries[selectedIndex]
         libraryManager.switchLibrary(id: selectedLibrary.id)
     }
-    
+
     private func setupStatusLabel() {
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         statusLabel.isEditable = false
@@ -308,7 +284,7 @@ class DownloadViewController: NSViewController {
         statusLabel.textColor = NSColor.secondaryLabelColor
         statusLabel.stringValue = ""
         view.addSubview(statusLabel)
-        
+
         NSLayoutConstraint.activate([
             statusLabel.topAnchor.constraint(equalTo: urlTextField.bottomAnchor, constant: 12),
             statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
@@ -316,7 +292,7 @@ class DownloadViewController: NSViewController {
             statusLabel.heightAnchor.constraint(equalToConstant: 16)
         ])
     }
-    
+
     private func setupProgressIndicator() {
         progressIndicator.translatesAutoresizingMaskIntoConstraints = false
         progressIndicator.style = .spinning
@@ -324,7 +300,7 @@ class DownloadViewController: NSViewController {
         progressIndicator.isIndeterminate = true
         progressIndicator.isHidden = true
         view.addSubview(progressIndicator)
-        
+
         NSLayoutConstraint.activate([
             progressIndicator.centerYAnchor.constraint(equalTo: statusLabel.centerYAnchor),
             progressIndicator.trailingAnchor.constraint(equalTo: statusLabel.trailingAnchor),
@@ -332,7 +308,7 @@ class DownloadViewController: NSViewController {
             progressIndicator.heightAnchor.constraint(equalToConstant: 16)
         ])
     }
-    
+
     private func setupTableView() {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
@@ -340,8 +316,7 @@ class DownloadViewController: NSViewController {
         scrollView.autohidesScrollers = true
         scrollView.borderType = .noBorder
         scrollView.drawsBackground = false
-        
-        // Use translucent material background
+
         tableBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         tableBackgroundView.material = .popover
         tableBackgroundView.state = .active
@@ -350,21 +325,21 @@ class DownloadViewController: NSViewController {
         tableBackgroundView.layer?.masksToBounds = true
         view.addSubview(tableBackgroundView)
         view.addSubview(scrollView)
-        
+
         NSLayoutConstraint.activate([
             tableBackgroundView.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 12),
             tableBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             tableBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             tableBackgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -50)
         ])
-        
+
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: tableBackgroundView.topAnchor, constant: 0),
             scrollView.leadingAnchor.constraint(equalTo: tableBackgroundView.leadingAnchor, constant: 0),
             scrollView.trailingAnchor.constraint(equalTo: tableBackgroundView.trailingAnchor, constant: 0),
             scrollView.bottomAnchor.constraint(equalTo: tableBackgroundView.bottomAnchor, constant: 0)
         ])
-        
+
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.headerView = nil
         tableView.allowsMultipleSelection = false
@@ -374,20 +349,19 @@ class DownloadViewController: NSViewController {
         tableView.selectionHighlightStyle = .none
         tableView.backgroundColor = .clear
         tableView.enclosingScrollView?.drawsBackground = false
-        tableView.gridStyleMask = [] 
+        tableView.gridStyleMask = []
         tableView.usesAlternatingRowBackgroundColors = false
-        
+
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("FormatColumn"))
         column.width = scrollView.frame.width - 20
         tableView.addTableColumn(column)
-        
+
         scrollView.documentView = tableView
-        
-        // Hide background view and table in initial state
+
         tableBackgroundView.isHidden = true
         scrollView.isHidden = true
     }
-    
+
     private func setupVersionInfo() {
         versionInfoLabel.translatesAutoresizingMaskIntoConstraints = false
         versionInfoLabel.isEditable = false
@@ -397,14 +371,14 @@ class DownloadViewController: NSViewController {
         versionInfoLabel.font = NSFont.systemFont(ofSize: 10)
         versionInfoLabel.textColor = NSColor.tertiaryLabelColor
         view.addSubview(versionInfoLabel)
-        
+
         NSLayoutConstraint.activate([
             versionInfoLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             versionInfoLabel.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -12),
             versionInfoLabel.heightAnchor.constraint(equalToConstant: 16)
         ])
     }
-    
+
     private func setupGithubLink() {
         githubLinkButton.translatesAutoresizingMaskIntoConstraints = false
         githubLinkButton.title = "GitHub"
@@ -414,7 +388,7 @@ class DownloadViewController: NSViewController {
         githubLinkButton.action = #selector(openGithub)
         githubLinkButton.font = NSFont.systemFont(ofSize: 10)
         githubLinkButton.contentTintColor = NSColor.linkColor
-        
+
         let trackingArea = NSTrackingArea(
             rect: NSRect.zero,
             options: [.inVisibleRect, .activeAlways, .mouseEnteredAndExited],
@@ -422,36 +396,35 @@ class DownloadViewController: NSViewController {
             userInfo: ["button": "github"]
         )
         githubLinkButton.addTrackingArea(trackingArea)
-        
+
         view.addSubview(githubLinkButton)
-        
+
         NSLayoutConstraint.activate([
             githubLinkButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             githubLinkButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -12),
             githubLinkButton.heightAnchor.constraint(equalToConstant: 16)
         ])
     }
-    
-    // MARK: - Mouse Tracking for GitHub Link
+
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
         if let userInfo = event.trackingArea?.userInfo as? [String: String] {
             if userInfo["button"] == "github" {
                 let attributedString = NSMutableAttributedString(string: githubLinkButton.title)
-                attributedString.addAttribute(.underlineStyle, 
-                                             value: NSUnderlineStyle.single.rawValue, 
+                attributedString.addAttribute(.underlineStyle,
+                                             value: NSUnderlineStyle.single.rawValue,
                                              range: NSRange(location: 0, length: attributedString.length))
                 githubLinkButton.attributedTitle = attributedString
             } else if userInfo["button"] == "nextPage" {
                 let attributedString = NSMutableAttributedString(string: nextPageButton.title)
-                attributedString.addAttribute(.underlineStyle, 
-                                             value: NSUnderlineStyle.single.rawValue, 
+                attributedString.addAttribute(.underlineStyle,
+                                             value: NSUnderlineStyle.single.rawValue,
                                              range: NSRange(location: 0, length: attributedString.length))
                 nextPageButton.attributedTitle = attributedString
             }
         }
     }
-    
+
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         if let userInfo = event.trackingArea?.userInfo as? [String: String] {
@@ -462,8 +435,7 @@ class DownloadViewController: NSViewController {
             }
         }
     }
-    
-    // MARK: - Dependencies Check
+
     private func scheduleDependencyCheckIfNeeded() {
         guard !hasScheduledDependencyCheck else { return }
         hasScheduledDependencyCheck = true
@@ -476,7 +448,6 @@ class DownloadViewController: NSViewController {
     private func checkDependencies() {
         var status = DependencyStatus(ytInstalled: false, ytVersion: "", ffmpegInstalled: false, ffmpegVersion: "")
 
-        // Shell script direct detection tool
         let script = """
         #!/bin/bash
         export PATH=$PATH:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/usr/bin
@@ -488,7 +459,7 @@ class DownloadViewController: NSViewController {
         else
             echo "YT_DLP_INSTALLED=false"
         fi
-        
+
         # Check ffmpeg
         if command -v ffmpeg &> /dev/null; then
             echo "FFMPEG_INSTALLED=true"
@@ -498,11 +469,11 @@ class DownloadViewController: NSViewController {
             echo "FFMPEG_INSTALLED=false"
         fi
         """
-        
+
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", script]
-        
+
         let pipe = Pipe()
         task.standardOutput = pipe
 
@@ -578,14 +549,13 @@ class DownloadViewController: NSViewController {
             if task.terminationStatus == 0 {
                 installed = true
 
-                // Get version
                 let versionTask = Process()
                 versionTask.launchPath = "/usr/bin/env"
                 versionTask.arguments = ["yt-dlp", "--version"]
-                
+
                 let versionPipe = Pipe()
                 versionTask.standardOutput = versionPipe
-                
+
                 try versionTask.run()
                 versionTask.waitUntilExit()
 
@@ -631,7 +601,7 @@ class DownloadViewController: NSViewController {
 
                 let versionPipe = Pipe()
                 versionTask.standardOutput = versionPipe
-                
+
                 try versionTask.run()
                 versionTask.waitUntilExit()
 
@@ -657,27 +627,26 @@ class DownloadViewController: NSViewController {
 
         return (installed, versionResult)
     }
-    
+
     private func updateVersionInfo() {
         var infoText = ""
-        
+
         if isYtDlpInstalled {
             infoText += "yt-dlp: v\(ytDlpVersion)"
         } else {
             infoText += "yt-dlp: " + NSLocalizedString("Not installed", comment: "")
         }
-        
+
         infoText += " | "
-        
+
         if isFfmpegInstalled {
             infoText += "ffmpeg: v\(ffmpegVersion)"
         } else {
             infoText += "ffmpeg: " + NSLocalizedString("Not installed", comment: "")
         }
-        
+
         versionInfoLabel.stringValue = infoText
-        
-        // If dependencies are missing, show a prompt
+
         if !isYtDlpInstalled || !isFfmpegInstalled {
             statusLabel.stringValue = NSLocalizedString("Please install missing dependencies", comment: "")
             statusLabel.textColor = NSColor.systemRed
@@ -685,20 +654,17 @@ class DownloadViewController: NSViewController {
             statusLabel.stringValue = ""
         }
     }
-    
-    // MARK: - Input Field Change
+
     @objc private func textFieldDidChange(_ notification: Notification) {
         if let textField = notification.object as? NSTextField, textField == urlTextField {
             updateButtonBasedOnInput()
         }
     }
-    
+
     private func updateButtonBasedOnInput() {
         let text = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        // Check URL type
+
         if text.hasPrefix("http://") || text.hasPrefix("https://") {
-            // Check if it's a playlist URL
             if DownloadManager.shared.isPlaylistURL(text) {
                 detectButton.title = NSLocalizedString("Load Playlist", comment: "")
                 isSearchMode = false
@@ -714,26 +680,23 @@ class DownloadViewController: NSViewController {
             isPlaylistMode = false
         }
     }
-    
-    // MARK: - Config Updated
+
     @objc private func handleConfigUpdated() {
-        // When configuration is updated, can do something here, e.g., clear previous search results
         searchResults = []
         if isSearchMode {
             tableView.reloadData()
         }
     }
-    
-    // MARK: - Actions
+
     @objc private func detectOrSearch() {
         let input = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         if input.isEmpty {
             statusLabel.stringValue = NSLocalizedString("Please enter a URL or search keyword", comment: "")
             statusLabel.textColor = NSColor.systemRed
             return
         }
-        
+
         if isSearchMode {
             performSearch(keyword: input)
         } else if isPlaylistMode {
@@ -742,54 +705,47 @@ class DownloadViewController: NSViewController {
             detectFormats()
         }
     }
-    
+
     private func performSearch(keyword: String, pageToken: String? = nil) {
-        // Validate configuration
         if !configManager.isConfigValid {
             showConfigRequiredPrompt()
             return
         }
-        
-        // Update last search keyword
+
         lastSearchKeyword = keyword
-        
-        // UI preparation before starting search
+
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.3
             progressIndicator.isHidden = false
             progressIndicator.startAnimation(nil)
-            statusLabel.stringValue = pageToken == nil ? 
-                NSLocalizedString("Searching...", comment: "") : 
+            statusLabel.stringValue = pageToken == nil ?
+                NSLocalizedString("Searching...", comment: "") :
                 NSLocalizedString("Load more results...", comment: "")
             statusLabel.textColor = NSColor.secondaryLabelColor
         })
-        
-        // If it's a new search (no pageToken), clear old results and previous pageToken
+
         if pageToken == nil {
             searchResults = []
-            currentNextPageToken = nil  // Reset token
-            nextPageButton.isHidden = true  // Hide next page button until more results are confirmed
-            downloadAllButton.isHidden = true  // Hide download all button
+            currentNextPageToken = nil
+            nextPageButton.isHidden = true
+            downloadAllButton.isHidden = true
             tableView.reloadData()
         }
-        
-        // Execute search
+
         ytSearchManager.search(keyword: keyword, pageToken: pageToken) { [weak self] result in
             guard let self = self else { return }
-            
+
             DispatchQueue.main.async {
                 self.hideProgressIndicator()
-                
+
                 switch result {
                 case .success(let searchResult):
-                    // Save or append search results
                     if pageToken == nil {
                         self.searchResults = searchResult.items
                     } else {
                         self.searchResults.append(contentsOf: searchResult.items)
                     }
-                    
-                    // Save nextPageToken for next page loading, ensure empty string is treated as nil
+
                     let hasNextPage: Bool
                     if let token = searchResult.nextPageToken, !token.isEmpty {
                         self.currentNextPageToken = token
@@ -798,25 +754,20 @@ class DownloadViewController: NSViewController {
                         self.currentNextPageToken = nil
                         hasNextPage = false
                     }
-                    
-                    // Update UI
+
                     if !self.searchResults.isEmpty {
                         self.tableBackgroundView.isHidden = false
                         self.scrollView.isHidden = false
                         self.updateSearchStatus(totalResults: searchResult.totalResults, hasNextPage: hasNextPage)
-                        
-                        // Update nextPageToken and pagination button - explicitly check if there's a next page
+
                         self.nextPageButton.isHidden = !hasNextPage
-                        
-                        // Adjust nextPageButton position based on whether there's a next page
+
                         if hasNextPage {
-                            // Dynamically adjust nextPageButton position, place it after text
                             let textWidth = self.statusLabel.attributedStringValue.size().width
                             self.nextPageButtonLeadingConstraint?.constant = textWidth + 10
                             self.view.layoutSubtreeIfNeeded()
                         }
-                        
-                        // Adjust window size
+
                         if let window = self.view.window {
                             let expandedHeight: CGFloat = min(540, 140 + CGFloat(min(8, self.searchResults.count)) * 40 + 60)
                             let newFrame = NSRect(
@@ -831,14 +782,13 @@ class DownloadViewController: NSViewController {
                         self.statusLabel.stringValue = NSLocalizedString("No results found", comment: "")
                         self.statusLabel.textColor = NSColor.secondaryLabelColor
                     }
-                    
+
                     self.tableView.reloadData()
-                    
+
                 case .failure(let error):
                     self.statusLabel.stringValue = String(format: NSLocalizedString("Search Error: %@", comment: ""), error.localizedDescription)
                     self.statusLabel.textColor = NSColor.systemRed
-                    
-                    // Provide more detailed error information and suggestions
+
                     if let nsError = error as NSError? {
                         if nsError.domain == "YTSearchManager" && nsError.code == 1001 {
                             self.statusLabel.stringValue = NSLocalizedString("Search error: API configuration not completed, please set API URL and API Key", comment: "")
@@ -850,23 +800,21 @@ class DownloadViewController: NSViewController {
                             self.statusLabel.stringValue = NSLocalizedString("Search error: Server error, please try again later", comment: "")
                         }
                     }
-                    
-                    // Add copy error button
+
                     let copyButton = NSButton(frame: NSRect(x: 0, y: 0, width: 80, height: 20))
                     copyButton.title = NSLocalizedString("Copy error", comment: "")
                     copyButton.bezelStyle = .inline
                     copyButton.target = self
                     copyButton.action = #selector(self.copyErrorMessage)
-                    copyButton.tag = 100 // For identification
-                    
-                    // Remove existing copy button
+                    copyButton.tag = 100
+
                     for subview in self.view.subviews {
                         if let button = subview as? NSButton, button.tag == 100 {
                             button.removeFromSuperview()
                             break
                         }
                     }
-                    
+
                     self.view.addSubview(copyButton)
                     copyButton.translatesAutoresizingMaskIntoConstraints = false
                     NSLayoutConstraint.activate([
@@ -878,63 +826,55 @@ class DownloadViewController: NSViewController {
             }
         }
     }
-    
+
     @objc private func loadNextPage() {
-        // Check if there's a next page token
         guard let token = currentNextPageToken, !token.isEmpty else {
-            // If no next page, hide button
             nextPageButton.isHidden = true
             return
         }
-        
-        // Save current scroll position
+
         let scrollPosition = tableView.enclosingScrollView?.contentView.bounds.origin.y ?? 0
-        
-        // Use previous search keyword and current token to load next page
+
         performSearch(keyword: lastSearchKeyword, pageToken: token)
-        
-        // Restore scroll position after loading completes (needs to be executed on main thread)
+
         DispatchQueue.main.async { [weak self] in
             self?.tableView.enclosingScrollView?.contentView.scroll(to: NSPoint(x: 0, y: scrollPosition))
         }
     }
-    
+
     @objc private func copyErrorMessage() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(statusLabel.stringValue, forType: .string)
-        
-        // Show temporary success message
+
         let originalText = statusLabel.stringValue
         statusLabel.stringValue = NSLocalizedString("Copied to clipboard", comment: "")
         statusLabel.textColor = NSColor.systemGreen
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             self?.statusLabel.stringValue = originalText
             self?.statusLabel.textColor = NSColor.systemRed
         }
     }
-    
+
     private func showConfigRequiredPrompt() {
         statusLabel.stringValue = NSLocalizedString("Please configure the search service API (API URL and API Key)", comment: "")
         statusLabel.textColor = NSColor.systemRed
-        
-        // Add go to settings button
+
         let goToConfigButton = NSButton(frame: NSRect(x: 0, y: 0, width: 80, height: 20))
         goToConfigButton.title = NSLocalizedString("Go to settings", comment: "")
         goToConfigButton.bezelStyle = .inline
         goToConfigButton.target = self
         goToConfigButton.action = #selector(openConfigWindow)
-        goToConfigButton.tag = 101 // For identification
-        
-        // Remove existing button
+        goToConfigButton.tag = 101
+
         for subview in self.view.subviews {
             if let button = subview as? NSButton, button.tag == 101 {
                 button.removeFromSuperview()
                 break
             }
         }
-        
+
         view.addSubview(goToConfigButton)
         goToConfigButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -943,23 +883,22 @@ class DownloadViewController: NSViewController {
             goToConfigButton.heightAnchor.constraint(equalToConstant: 20)
         ])
     }
-    
+
     @objc private func openConfigWindow() {
         if let appDelegate = NSApp.delegate as? AppDelegate {
             appDelegate.showConfigWindow()
         }
     }
-    
+
     private func loadPlaylist() {
         let urlString = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         if urlString.isEmpty {
             statusLabel.stringValue = NSLocalizedString("Please enter a valid playlist URL", comment: "")
             statusLabel.textColor = NSColor.systemRed
             return
         }
-        
-        // Start loading state
+
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.3
             progressIndicator.isHidden = false
@@ -967,16 +906,14 @@ class DownloadViewController: NSViewController {
             statusLabel.stringValue = NSLocalizedString("Loading playlist information...", comment: "")
             statusLabel.textColor = NSColor.secondaryLabelColor
         })
-        
-        // Clear previous data
+
         formats = []
         searchResults = []
         currentPlaylist = nil
         tableView.reloadData()
         nextPageButton.isHidden = true
         downloadAllButton.isHidden = true
-        
-        // Execute playlist loading
+
         Task {
             do {
                 if !self.isYtDlpInstalled {
@@ -987,7 +924,7 @@ class DownloadViewController: NSViewController {
                     }
                     return
                 }
-                
+
                 if !self.isFfmpegInstalled {
                     DispatchQueue.main.async {
                         self.hideProgressIndicator()
@@ -996,32 +933,30 @@ class DownloadViewController: NSViewController {
                     }
                     return
                 }
-                
+
                 let playlistInfo = try await DownloadManager.shared.fetchPlaylistInfo(from: urlString)
-                
+
                 DispatchQueue.main.async {
                     self.currentPlaylist = playlistInfo
                     self.hideProgressIndicator()
-                    
+
                     if !playlistInfo.items.isEmpty {
                         NSAnimationContext.runAnimationGroup({ context in
                             context.duration = 0.3
                             self.tableBackgroundView.isHidden = false
                             self.scrollView.isHidden = false
                             self.downloadAllButton.isHidden = false
-                            
-                            // Limit status text length to avoid covering button
+
                             let maxLength = 40
-                            let truncatedTitle = playlistInfo.title.count > maxLength ? 
-                                String(playlistInfo.title.prefix(maxLength)) + "..." : 
+                            let truncatedTitle = playlistInfo.title.count > maxLength ?
+                                String(playlistInfo.title.prefix(maxLength)) + "..." :
                                 playlistInfo.title
-                            
+
                             self.statusLabel.stringValue = String(format: NSLocalizedString("Playlist: %@ (%d items)", comment: ""), truncatedTitle, playlistInfo.videoCount)
                             self.statusLabel.textColor = NSColor.secondaryLabelColor
                         }, completionHandler: {
                             self.tableView.reloadData()
-                            
-                            // Adjust window size
+
                             if let window = self.view.window {
                                 let expandedHeight: CGFloat = min(540, 140 + CGFloat(min(8, playlistInfo.items.count)) * 40 + 60)
                                 let newFrame = NSRect(
@@ -1047,36 +982,31 @@ class DownloadViewController: NSViewController {
             }
         }
     }
-    
+
     @objc private func detectFormats() {
         let urlString = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         if urlString.isEmpty {
             statusLabel.stringValue = NSLocalizedString("Please enter a valid URL", comment: "")
             statusLabel.textColor = NSColor.systemRed
             return
         }
-        
-        // Add smooth UI state transition
+
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.3
-            // Show progress indicator
             progressIndicator.isHidden = false
             progressIndicator.startAnimation(nil)
-            
-            // Update status label
+
             statusLabel.stringValue = NSLocalizedString("Detecting available formats...", comment: "")
             statusLabel.textColor = NSColor.secondaryLabelColor
         })
-        
+
         formats = []
         tableView.reloadData()
-        
-        // Hide buttons in detect mode
+
         nextPageButton.isHidden = true
         downloadAllButton.isHidden = true
-        
-        // Use Task to execute asynchronous operations
+
         Task {
             do {
                 if !self.isYtDlpInstalled {
@@ -1087,7 +1017,7 @@ class DownloadViewController: NSViewController {
                     }
                     return
                 }
-                
+
                 if !self.isFfmpegInstalled {
                     DispatchQueue.main.async {
                         self.hideProgressIndicator()
@@ -1096,35 +1026,35 @@ class DownloadViewController: NSViewController {
                     }
                     return
                 }
-                
+
                 let newFormats = try await DownloadManager.shared.fetchAvailableFormats(from: urlString)
-                
+
                 DispatchQueue.main.async {
                     self.formats = newFormats
-                    
+
                     if !self.formats.isEmpty {
                         NSAnimationContext.runAnimationGroup({ context in
                             context.duration = 0.3
                             self.hideProgressIndicator()
-                            
+
                             self.tableBackgroundView.isHidden = false
                             self.scrollView.isHidden = false
-                            
+
                             self.statusLabel.stringValue = String(format: NSLocalizedString("Found %d available formats", comment: ""), self.formats.count)
                             self.statusLabel.textColor = NSColor.secondaryLabelColor
                         }, completionHandler: {
                             self.tableView.reloadData()
-                            
+
                             if let window = self.view.window {
                                 let expandedHeight: CGFloat = min(540, 140 + CGFloat(min(8, self.formats.count)) * 40 + 60)
-                                
+
                                 let newFrame = NSRect(
                                     x: window.frame.origin.x,
                                     y: window.frame.origin.y + window.frame.height - expandedHeight,
                                     width: window.frame.width,
                                     height: expandedHeight
                                 )
-                                
+
                                 window.animator().setFrame(newFrame, display: true)
                             }
                         })
@@ -1143,22 +1073,20 @@ class DownloadViewController: NSViewController {
             }
         }
     }
-    
+
     private func hideProgressIndicator() {
         progressIndicator.isHidden = true
         progressIndicator.stopAnimation(nil)
     }
-    
-    // Status display when search completes
+
     private func updateSearchStatus(totalResults: Int, hasNextPage: Bool) {
         let statusText = String(format: NSLocalizedString("Found %d results", comment: ""), totalResults)
         statusLabel.stringValue = statusText
         statusLabel.textColor = NSColor.secondaryLabelColor
-        
-        // Control next page button visibility
+
         nextPageButton.isHidden = !hasNextPage
     }
-    
+
     @objc private func downloadAudio(sender: NSButton) {
         if isDownloading {
             sender.title = NSLocalizedString("Download", comment: "")
@@ -1245,7 +1173,7 @@ class DownloadViewController: NSViewController {
             }
         }
     }
-    
+
     private func showAlert(message: String) {
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Information", comment: "")
@@ -1254,7 +1182,7 @@ class DownloadViewController: NSViewController {
         alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
         alert.beginSheetModal(for: view.window!) { _ in }
     }
-    
+
     @objc private func openGithub() {
         if let url = URL(string: "https://github.com/samzong/macmusicplayer") {
             NSWorkspace.shared.open(url)
@@ -1262,11 +1190,9 @@ class DownloadViewController: NSViewController {
     }
 }
 
-// MARK: - NSTableViewDataSource & NSTableViewDelegate
 extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
     func numberOfRows(in tableView: NSTableView) -> Int {
         if isSearchMode {
-            // If there's an expanded row, add format option count
             if let expandedRow = expandedVideoRow, expandedRow < searchResults.count {
                 return searchResults.count + formatOptions.count
             }
@@ -1277,15 +1203,13 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             return formats.count
         }
     }
-    
+
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         if isSearchMode {
-            // Check if it's a format option row
             if let expandedRow = expandedVideoRow, row > expandedRow && row <= expandedRow + formatOptions.count {
                 return getFormatOptionCellView(for: row - expandedRow - 1)
             }
-            
-            // Normal search result row
+
             let actualRow = row > expandedVideoRow ?? -1 ? row - formatOptions.count : row
             return getSearchResultCellView(for: actualRow)
         } else if isPlaylistMode {
@@ -1294,36 +1218,34 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             return getFormatCellView(for: row)
         }
     }
-    
+
     private func getSearchResultCellView(for row: Int) -> NSView? {
         let video = searchResults[row]
-        
+
         let cellIdentifier = NSUserInterfaceItemIdentifier("SearchCell")
         var cell = tableView.makeView(withIdentifier: cellIdentifier, owner: self) as? NSTableCellView
-        
+
         if cell == nil {
             cell = NSTableCellView()
             cell?.identifier = cellIdentifier
-            
+
             let containerView = NSView()
             containerView.translatesAutoresizingMaskIntoConstraints = false
             cell?.addSubview(containerView)
-            
+
             NSLayoutConstraint.activate([
                 containerView.leadingAnchor.constraint(equalTo: cell!.leadingAnchor, constant: 5),
                 containerView.trailingAnchor.constraint(equalTo: cell!.trailingAnchor, constant: -5),
                 containerView.topAnchor.constraint(equalTo: cell!.topAnchor),
                 containerView.bottomAnchor.constraint(equalTo: cell!.bottomAnchor)
             ])
-            
-            // Thumbnail
+
             let thumbnailView = NSImageView()
             thumbnailView.identifier = NSUserInterfaceItemIdentifier("ThumbnailView")
             thumbnailView.translatesAutoresizingMaskIntoConstraints = false
             thumbnailView.imageScaling = .scaleProportionallyUpOrDown
             containerView.addSubview(thumbnailView)
-            
-            // Title text
+
             let titleField = NSTextField()
             titleField.identifier = NSUserInterfaceItemIdentifier("TitleField")
             titleField.translatesAutoresizingMaskIntoConstraints = false
@@ -1334,8 +1256,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             titleField.font = NSFont.systemFont(ofSize: 12)
             titleField.lineBreakMode = .byTruncatingTail
             containerView.addSubview(titleField)
-            
-            // Detail button
+
             let detailButton = NSButton()
             detailButton.identifier = NSUserInterfaceItemIdentifier("DetailButton")
             detailButton.translatesAutoresizingMaskIntoConstraints = false
@@ -1345,8 +1266,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             detailButton.target = self
             detailButton.action = #selector(openVideoDetail(sender:))
             containerView.addSubview(detailButton)
-            
-            // Detect button
+
             let detectButton = NSButton()
             detectButton.identifier = NSUserInterfaceItemIdentifier("VideoDetectButton")
             detectButton.translatesAutoresizingMaskIntoConstraints = false
@@ -1356,40 +1276,38 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             detectButton.target = self
             detectButton.action = #selector(detectVideoFormats(sender:))
             detectButton.contentTintColor = NSColor.white
-            
+
             if #available(macOS 11.0, *) {
                 detectButton.bezelColor = NSColor.controlAccentColor
             } else {
                 detectButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
             }
-            
+
             containerView.addSubview(detectButton)
-            
+
             NSLayoutConstraint.activate([
                 thumbnailView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 5),
                 thumbnailView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 thumbnailView.widthAnchor.constraint(equalToConstant: 40),
                 thumbnailView.heightAnchor.constraint(equalToConstant: 30),
-                
+
                 titleField.leadingAnchor.constraint(equalTo: thumbnailView.trailingAnchor, constant: 10),
                 titleField.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 titleField.trailingAnchor.constraint(equalTo: detailButton.leadingAnchor, constant: -10),
-                
+
                 detectButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5),
                 detectButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 detectButton.widthAnchor.constraint(equalToConstant: 60),
                 detectButton.heightAnchor.constraint(equalToConstant: 26),
-                
+
                 detailButton.trailingAnchor.constraint(equalTo: detectButton.leadingAnchor, constant: -5),
                 detailButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 detailButton.widthAnchor.constraint(equalToConstant: 60),
                 detailButton.heightAnchor.constraint(equalToConstant: 26)
             ])
         }
-        
-        // Update thumbnail
+
         if let thumbnailView = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "ThumbnailView" }) as? NSImageView {
-            // Asynchronously load thumbnail
             DispatchQueue.global().async {
                 if let url = URL(string: video.thumbnailUrl),
                    let imageData = try? Data(contentsOf: url),
@@ -1404,45 +1322,43 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                 }
             }
         }
-        
-        // Update title
+
         if let titleField = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "TitleField" }) as? NSTextField {
             titleField.stringValue = video.title
         }
-        
-        // Update button tags
+
         if let detailButton = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "DetailButton" }) as? NSButton {
             detailButton.tag = row
         }
-        
+
         if let detectButton = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "VideoDetectButton" }) as? NSButton {
             detectButton.tag = row
         }
-        
+
         return cell
     }
-    
+
     private func getFormatCellView(for row: Int) -> NSView? {
         let format = formats[row]
-        
+
         let cellIdentifier = NSUserInterfaceItemIdentifier("FormatCell")
         var cell = tableView.makeView(withIdentifier: cellIdentifier, owner: self) as? NSTableCellView
-        
+
         if cell == nil {
             cell = NSTableCellView()
             cell?.identifier = cellIdentifier
-            
+
             let containerView = NSView()
             containerView.translatesAutoresizingMaskIntoConstraints = false
             cell?.addSubview(containerView)
-            
+
             NSLayoutConstraint.activate([
                 containerView.leadingAnchor.constraint(equalTo: cell!.leadingAnchor, constant: 5),
                 containerView.trailingAnchor.constraint(equalTo: cell!.trailingAnchor, constant: -5),
                 containerView.topAnchor.constraint(equalTo: cell!.topAnchor),
                 containerView.bottomAnchor.constraint(equalTo: cell!.bottomAnchor)
             ])
-            
+
             let text = NSTextField()
             text.identifier = NSUserInterfaceItemIdentifier("FormatText")
             text.translatesAutoresizingMaskIntoConstraints = false
@@ -1454,8 +1370,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             text.lineBreakMode = .byTruncatingTail
             text.setAccessibilityLabel("Audio format")
             containerView.addSubview(text)
-            
-            // Download button - use a more modern style
+
             let downloadButton = NSButton()
             downloadButton.identifier = NSUserInterfaceItemIdentifier("DownloadButton")
             downloadButton.translatesAutoresizingMaskIntoConstraints = false
@@ -1464,16 +1379,16 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             downloadButton.font = NSFont.systemFont(ofSize: 12, weight: .medium)
             downloadButton.target = self
             downloadButton.action = #selector(downloadAudio(sender:))
-            downloadButton.setAccessibilityLabel("Download this audio format")            
+            downloadButton.setAccessibilityLabel("Download this audio format")
             downloadButton.wantsLayer = true
             downloadButton.contentTintColor = NSColor.white
-            
+
             if #available(macOS 11.0, *) {
                 downloadButton.bezelColor = NSColor.controlAccentColor
             } else {
                 downloadButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
             }
-            
+
             let trackingArea = NSTrackingArea(
                 rect: NSRect.zero,
                 options: [.inVisibleRect, .activeAlways, .mouseEnteredAndExited],
@@ -1481,76 +1396,70 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                 userInfo: nil
             )
             downloadButton.addTrackingArea(trackingArea)
-            
+
             let minButtonWidth: CGFloat = 90
             let buttonWidth = downloadButton.title.size(withAttributes: [.font: downloadButton.font!]).width + 20
             let actualButtonWidth = max(minButtonWidth, buttonWidth)
-            
+
             containerView.addSubview(downloadButton)
-            
+
             NSLayoutConstraint.activate([
                 text.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
                 text.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 text.trailingAnchor.constraint(equalTo: downloadButton.leadingAnchor, constant: -10),
-                
+
                 downloadButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5),
                 downloadButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 downloadButton.widthAnchor.constraint(equalToConstant: actualButtonWidth),
                 downloadButton.heightAnchor.constraint(equalToConstant: 26)
             ])
-            
+
             cell?.textField = text
         }
-        
+
         cell?.textField?.stringValue = format.description
-        
+
         if let downloadButton = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "DownloadButton" }) as? NSButton {
             downloadButton.tag = row
         }
-        
+
         return cell
     }
-    
+
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
         return 40
     }
-    
-    // MARK: - Search Result Actions
+
     @objc private func openVideoDetail(sender: NSButton) {
         let row = sender.tag
         guard row >= 0 && row < searchResults.count else { return }
-        
+
         let video = searchResults[row]
         if let url = URL(string: video.videoUrl) {
             NSWorkspace.shared.open(url)
         }
     }
-    
+
     @objc private func detectVideoFormats(sender: NSButton) {
         let row = sender.tag
         guard row >= 0 && row < searchResults.count else { return }
-        
+
         let video = searchResults[row]
-        
-        // Check if need to collapse currently expanded row
+
         if expandedVideoRow == row {
-            // If clicking the currently expanded row, collapse it
             expandedVideoRow = nil
             formatOptions = []
             tableView.reloadData()
             return
         } else if expandedVideoRow != nil {
-            // If another row is expanded, collapse it first
             expandedVideoRow = nil
             formatOptions = []
         }
-        
-        // Show loading state
+
         expandedVideoRow = row
         formatOptions = []
         tableView.reloadData()
-        
-        // Start loading button state update
+
         if let videoCell = tableView.rowView(atRow: row, makeIfNecessary: false),
            let cellContent = videoCell.view(atColumn: 0) as? NSView,
            let detectBtn = cellContent.subviews.first?.subviews.first(where: { ($0 as? NSButton)?.action == #selector(detectVideoFormats(sender:)) }) as? NSButton {
@@ -1560,22 +1469,18 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                 detectBtn.animator().alphaValue = 0.6
             })
         }
-        
-        // Create a loading option
+
         let loadingOption = FormatOption(title: NSLocalizedString("Loading formats...", comment: ""), formatId: "", videoItem: video)
         formatOptions = [loadingOption]
         tableView.reloadData()
-        
-        // Actually execute format detection
+
         Task {
             do {
                 let detectedFormats = try await DownloadManager.shared.fetchAvailableFormats(from: video.videoUrl)
-                
-                // Update UI on main thread
+
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self, self.expandedVideoRow == row else { return }
-                    
-                    // Convert detected formats to options
+
                     self.formatOptions = detectedFormats.map { format in
                         return FormatOption(
                             title: format.description,
@@ -1583,8 +1488,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                             videoItem: video
                         )
                     }
-                    
-                    // Re-enable detect button
+
                     if let videoCell = self.tableView.rowView(atRow: row, makeIfNecessary: false),
                        let cellContent = videoCell.view(atColumn: 0) as? NSView,
                        let detectBtn = cellContent.subviews.first?.subviews.first(where: { ($0 as? NSButton)?.action == #selector(self.detectVideoFormats(sender:)) }) as? NSButton {
@@ -1594,16 +1498,13 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                             detectBtn.animator().alphaValue = 1.0
                         })
                     }
-                    
-                    // Refresh table to show actual formats
+
                     self.tableView.reloadData()
                 }
             } catch {
-                // Handle error
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self, self.expandedVideoRow == row else { return }
-                    
-                    // Show error message
+
                     self.formatOptions = [
                         FormatOption(
                             title: String(format: NSLocalizedString("Error: %@", comment: ""), error.localizedDescription),
@@ -1611,8 +1512,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                             videoItem: video
                         )
                     ]
-                    
-                    // Re-enable detect button
+
                     if let videoCell = self.tableView.rowView(atRow: row, makeIfNecessary: false),
                        let cellContent = videoCell.view(atColumn: 0) as? NSView,
                        let detectBtn = cellContent.subviews.first?.subviews.first(where: { ($0 as? NSButton)?.action == #selector(self.detectVideoFormats(sender:)) }) as? NSButton {
@@ -1622,71 +1522,65 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                             detectBtn.animator().alphaValue = 1.0
                         })
                     }
-                    
-                    // Refresh table to show error message
+
                     self.tableView.reloadData()
                 }
             }
         }
     }
-    
+
     @objc private func downloadFormatOption(sender: NSButton) {
         let optionIndex = sender.tag
         guard optionIndex >= 0 && optionIndex < formatOptions.count else { return }
-        
+
         let option = formatOptions[optionIndex]
-        
-        // Check if there's a valid formatId
+
         if option.formatId.isEmpty {
-            return // Skip invalid options (e.g., loading or error messages)
+            return
         }
-        
-        // Directly download specified format
+
         downloadSpecificFormat(video: option.videoItem, formatId: option.formatId, formatName: option.title)
-        
-        // Collapse expanded row
+
         expandedVideoRow = nil
         formatOptions = []
         tableView.reloadData()
     }
-    
+
     func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
         let identifier = NSUserInterfaceItemIdentifier("FormatRowView")
         var rowView = tableView.makeView(withIdentifier: identifier, owner: self) as? CustomTableRowView
-        
+
         if rowView == nil {
             rowView = CustomTableRowView()
             rowView?.identifier = identifier
         }
-        
+
         return rowView
     }
-    
-    // Add method to get format option row view
+
     private func getFormatOptionCellView(for optionIndex: Int) -> NSView? {
         guard optionIndex >= 0 && optionIndex < formatOptions.count else { return nil }
-        
+
         let option = formatOptions[optionIndex]
-        
+
         let cellIdentifier = NSUserInterfaceItemIdentifier("FormatOptionCell")
         var cell = tableView.makeView(withIdentifier: cellIdentifier, owner: self) as? NSTableCellView
-        
+
         if cell == nil {
             cell = NSTableCellView()
             cell?.identifier = cellIdentifier
-            
+
             let containerView = NSView()
             containerView.translatesAutoresizingMaskIntoConstraints = false
             cell?.addSubview(containerView)
-            
+
             NSLayoutConstraint.activate([
                 containerView.leadingAnchor.constraint(equalTo: cell!.leadingAnchor),
                 containerView.trailingAnchor.constraint(equalTo: cell!.trailingAnchor),
                 containerView.topAnchor.constraint(equalTo: cell!.topAnchor),
                 containerView.bottomAnchor.constraint(equalTo: cell!.bottomAnchor)
             ])
-            
-            // Format option display text
+
             let formatLabel = NSTextField()
             formatLabel.identifier = NSUserInterfaceItemIdentifier("FormatOptionLabel")
             formatLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -1697,8 +1591,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             formatLabel.font = NSFont.systemFont(ofSize: 12)
             formatLabel.lineBreakMode = .byTruncatingTail
             containerView.addSubview(formatLabel)
-            
-            // Download button
+
             let downloadButton = NSButton()
             downloadButton.identifier = NSUserInterfaceItemIdentifier("FormatOptionDownloadButton")
             downloadButton.translatesAutoresizingMaskIntoConstraints = false
@@ -1708,36 +1601,34 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             downloadButton.target = self
             downloadButton.action = #selector(downloadFormatOption(sender:))
             downloadButton.contentTintColor = NSColor.white
-            
+
             if #available(macOS 11.0, *) {
                 downloadButton.bezelColor = NSColor.controlAccentColor
             } else {
                 downloadButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
             }
-            
+
             containerView.addSubview(downloadButton)
-            
+
             NSLayoutConstraint.activate([
                 formatLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 25),
                 formatLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 formatLabel.trailingAnchor.constraint(equalTo: downloadButton.leadingAnchor, constant: -10),
-                
+
                 downloadButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5),
                 downloadButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 downloadButton.widthAnchor.constraint(equalToConstant: 70),
                 downloadButton.heightAnchor.constraint(equalToConstant: 26)
             ])
         }
-        
-        // Update text and button
+
         if let label = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "FormatOptionLabel" }) as? NSTextField {
             label.stringValue = option.title
         }
-        
+
         if let button = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "FormatOptionDownloadButton" }) as? NSButton {
             button.tag = optionIndex
-            
-            // Control button state based on whether option is valid
+
             if option.formatId.isEmpty {
                 button.isEnabled = false
                 button.isHidden = option.title.starts(with: "Error") ? true : false
@@ -1746,34 +1637,33 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                 button.isHidden = false
             }
         }
-        
+
         return cell
     }
-    
+
     private func getPlaylistItemCellView(for row: Int) -> NSView? {
         guard let playlist = currentPlaylist, row >= 0 && row < playlist.items.count else { return nil }
-        
+
         let item = playlist.items[row]
-        
+
         let cellIdentifier = NSUserInterfaceItemIdentifier("PlaylistItemCell")
         var cell = tableView.makeView(withIdentifier: cellIdentifier, owner: self) as? NSTableCellView
-        
+
         if cell == nil {
             cell = NSTableCellView()
             cell?.identifier = cellIdentifier
-            
+
             let containerView = NSView()
             containerView.translatesAutoresizingMaskIntoConstraints = false
             cell?.addSubview(containerView)
-            
+
             NSLayoutConstraint.activate([
                 containerView.leadingAnchor.constraint(equalTo: cell!.leadingAnchor, constant: 5),
                 containerView.trailingAnchor.constraint(equalTo: cell!.trailingAnchor, constant: -5),
                 containerView.topAnchor.constraint(equalTo: cell!.topAnchor),
                 containerView.bottomAnchor.constraint(equalTo: cell!.bottomAnchor)
             ])
-            
-            // Index label
+
             let numberLabel = NSTextField()
             numberLabel.identifier = NSUserInterfaceItemIdentifier("NumberLabel")
             numberLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -1785,8 +1675,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             numberLabel.textColor = NSColor.secondaryLabelColor
             numberLabel.alignment = .center
             containerView.addSubview(numberLabel)
-            
-            // Title text
+
             let titleField = NSTextField()
             titleField.identifier = NSUserInterfaceItemIdentifier("PlaylistTitleField")
             titleField.translatesAutoresizingMaskIntoConstraints = false
@@ -1797,8 +1686,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             titleField.font = NSFont.systemFont(ofSize: 12)
             titleField.lineBreakMode = .byTruncatingTail
             containerView.addSubview(titleField)
-            
-            // Duration label
+
             let durationLabel = NSTextField()
             durationLabel.identifier = NSUserInterfaceItemIdentifier("DurationLabel")
             durationLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -1810,38 +1698,37 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             durationLabel.textColor = NSColor.secondaryLabelColor
             durationLabel.alignment = .right
             containerView.addSubview(durationLabel)
-            
+
             NSLayoutConstraint.activate([
                 numberLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 5),
                 numberLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 numberLabel.widthAnchor.constraint(equalToConstant: 30),
-                
+
                 titleField.leadingAnchor.constraint(equalTo: numberLabel.trailingAnchor, constant: 10),
                 titleField.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 titleField.trailingAnchor.constraint(equalTo: durationLabel.leadingAnchor, constant: -10),
-                
+
                 durationLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5),
                 durationLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 durationLabel.widthAnchor.constraint(equalToConstant: 60)
             ])
         }
-        
-        // Update content
+
         if let numberLabel = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "NumberLabel" }) as? NSTextField {
             numberLabel.stringValue = "\(row + 1)"
         }
-        
+
         if let titleField = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "PlaylistTitleField" }) as? NSTextField {
             titleField.stringValue = item.title
         }
-        
+
         if let durationLabel = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "DurationLabel" }) as? NSTextField {
             durationLabel.stringValue = item.duration.isEmpty ? "Unknown" : item.duration
         }
-        
+
         return cell
     }
-    
+
     @objc private func downloadAllButtonTapped() {
         if isDownloading {
             stopDownload()
@@ -1849,7 +1736,7 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             startDownload()
         }
     }
-    
+
     private func stopDownload() {
         downloadTask?.cancel()
         downloadTask = nil
@@ -1878,32 +1765,30 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
         } else {
             downloadAllButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
         }
-        
+
         statusLabel.stringValue = NSLocalizedString("Download stopped", comment: "")
         statusLabel.textColor = NSColor.systemOrange
     }
-    
-    private func startDownload() {        
+
+    private func startDownload() {
         let urlString = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        // Update download status
+
         isDownloading = true
-        
-        // Change button to stop button
+
         downloadAllButton.title = NSLocalizedString("Stop", comment: "")
         downloadAllButton.contentTintColor = NSColor.white
-        
+
         if #available(macOS 11.0, *) {
             downloadAllButton.bezelColor = NSColor.systemRed
         } else {
             downloadAllButton.layer?.backgroundColor = NSColor.systemRed.cgColor
         }
-        
+
         progressIndicator.isHidden = false
         progressIndicator.startAnimation(nil)
         statusLabel.stringValue = NSLocalizedString("Starting playlist download...", comment: "")
         statusLabel.textColor = NSColor.secondaryLabelColor
-        
+
         downloadTask = Task {
             do {
                 try await DownloadManager.shared.downloadPlaylist(from: urlString) { [weak self] progress in
@@ -1911,63 +1796,57 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                         guard let self = self else { return }
                         guard self.isDownloading else { return }
 
-                        // Limit current song name length to avoid covering button
                         let maxTitleLength = 25
-                        let truncatedCurrentTitle = progress.currentTitle.count > maxTitleLength ? 
-                            String(progress.currentTitle.prefix(maxTitleLength)) + "..." : 
+                        let truncatedCurrentTitle = progress.currentTitle.count > maxTitleLength ?
+                            String(progress.currentTitle.prefix(maxTitleLength)) + "..." :
                             progress.currentTitle
-                        
-                        let statusText = String(format: NSLocalizedString("Downloading (%d/%d) - %@", comment: ""), 
-                                              progress.currentIndex, 
-                                              progress.totalCount, 
+
+                        let statusText = String(format: NSLocalizedString("Downloading (%d/%d) - %@", comment: ""),
+                                              progress.currentIndex,
+                                              progress.totalCount,
                                               truncatedCurrentTitle)
                         self.statusLabel.stringValue = statusText
                         self.statusLabel.textColor = NSColor.secondaryLabelColor
                     }
                 }
-                
+
                 DispatchQueue.main.async {
-                    // Check if task was cancelled
                     guard !Task.isCancelled else { return }
-                    
+
                     self.isDownloading = false
                     self.downloadTask = nil
                     self.activeDownloadButton = nil
                     self.hideProgressIndicator()
                     self.statusLabel.stringValue = NSLocalizedString("Playlist download completed", comment: "")
                     self.statusLabel.textColor = NSColor.systemGreen
-                    
-                    // Restore download button
+
                     self.downloadAllButton.title = NSLocalizedString("Download All", comment: "")
                     self.downloadAllButton.contentTintColor = NSColor.white
-                    
+
                     if #available(macOS 11.0, *) {
                         self.downloadAllButton.bezelColor = NSColor.controlAccentColor
                     } else {
                         self.downloadAllButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
                     }
-                    
-                    // Notify player to refresh music library
+
                     NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
                 }
             } catch {
                 DispatchQueue.main.async {
-                    // Check if it's a cancellation error
                     if error is CancellationError {
-                        return // Don't show error when cancelled, handled by stopDownload
+                        return
                     }
-                    
+
                     self.isDownloading = false
                     self.downloadTask = nil
                     self.activeDownloadButton = nil
                     self.hideProgressIndicator()
                     self.statusLabel.stringValue = String(format: NSLocalizedString("Playlist download failed: %@", comment: ""), error.localizedDescription)
                     self.statusLabel.textColor = NSColor.systemRed
-                    
-                    // Restore download button
+
                     self.downloadAllButton.title = NSLocalizedString("Download All", comment: "")
                     self.downloadAllButton.contentTintColor = NSColor.white
-                    
+
                     if #available(macOS 11.0, *) {
                         self.downloadAllButton.bezelColor = NSColor.controlAccentColor
                     } else {
@@ -1977,23 +1856,21 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             }
         }
     }
-    
+
     private func downloadSpecificFormat(video: YTSearchManager.SearchResult.VideoItem, formatId: String, formatName: String) {
-        // Show download progress
         progressIndicator.isHidden = false
         progressIndicator.startAnimation(nil)
         statusLabel.stringValue = String(format: NSLocalizedString("Downloading %@...", comment: ""), formatName)
-        
+
         Task {
             do {
                 try await DownloadManager.shared.downloadAudio(from: video.videoUrl, formatId: formatId)
-                
+
                 DispatchQueue.main.async {
                     self.hideProgressIndicator()
                     self.statusLabel.stringValue = NSLocalizedString("Download completed", comment: "")
                     self.statusLabel.textColor = NSColor.systemGreen
-                    
-                    // Notify player to refresh music library
+
                     NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
                 }
             } catch {

--- a/MacMusicPlayer/MacMusicPlayerApp.swift
+++ b/MacMusicPlayer/MacMusicPlayerApp.swift
@@ -1,16 +1,9 @@
-//
-//  MacMusicPlayerApp.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
-
 import SwiftUI
 
 @main
 struct MacMusicPlayerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     var body: some Scene {
         Settings {
             EmptyView()

--- a/MacMusicPlayer/Managers/ConfigManager.swift
+++ b/MacMusicPlayer/Managers/ConfigManager.swift
@@ -1,27 +1,18 @@
-//
-//  ConfigManager.swift
-//  MacMusicPlayer
-//
-//  Created by samzong<samzong.lu@gmail.com>
-//
-
 import Foundation
 
 class ConfigManager {
     static let shared = ConfigManager()
-    
+
     private let userDefaults = UserDefaults.standard
-    
-    // Keys for UserDefaults
+
     private enum Keys {
         static let apiKey = "ytSearchApiKey"
         static let apiUrl = "ytSearchApiUrl"
         static let showSongPickerOnLaunch = "showSongPickerOnLaunch"
     }
-    
+
     private init() {}
-    
-    // API Key related methods
+
     var apiKey: String {
         get {
             return userDefaults.string(forKey: Keys.apiKey) ?? ""
@@ -30,8 +21,7 @@ class ConfigManager {
             userDefaults.set(newValue, forKey: Keys.apiKey)
         }
     }
-    
-    // API URL related methods
+
     var apiUrl: String {
         get {
             return userDefaults.string(forKey: Keys.apiUrl) ?? ""
@@ -40,30 +30,26 @@ class ConfigManager {
             userDefaults.set(newValue, forKey: Keys.apiUrl)
         }
     }
-    
+
     var showSongPickerOnLaunch: Bool {
         get {
-            // Default to false if the preference has never been set
             return userDefaults.object(forKey: Keys.showSongPickerOnLaunch) as? Bool ?? false
         }
         set {
             userDefaults.set(newValue, forKey: Keys.showSongPickerOnLaunch)
         }
     }
-    
-    // Check if configuration is valid
+
     var isConfigValid: Bool {
         return !apiKey.isEmpty && !apiUrl.isEmpty
     }
-    
-    // Reset configuration
+
     func resetConfig() {
         userDefaults.removeObject(forKey: Keys.apiKey)
         userDefaults.removeObject(forKey: Keys.apiUrl)
         userDefaults.removeObject(forKey: Keys.showSongPickerOnLaunch)
     }
-    
-    // Save configuration
+
     func saveConfig(apiKey: String, apiUrl: String, showSongPickerOnLaunch: Bool) {
         self.apiKey = apiKey
         self.apiUrl = apiUrl

--- a/MacMusicPlayer/Managers/DownloadManager.swift
+++ b/MacMusicPlayer/Managers/DownloadManager.swift
@@ -1,10 +1,3 @@
-//
-//  DownloadManager.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
-
 import Foundation
 import AppKit
 
@@ -14,7 +7,6 @@ public class DownloadManager {
     private var libraryManager: LibraryManager
 
     private init() {
-        // Default to a standalone LibraryManager until the app delegate binds the shared instance.
         self.libraryManager = LibraryManager()
     }
 
@@ -22,7 +14,7 @@ public class DownloadManager {
     func updateLibraryManager(_ libraryManager: LibraryManager) {
         self.libraryManager = libraryManager
     }
-    
+
     public struct DownloadFormat {
         public let formatId: String
         public let fileExtension: String
@@ -31,7 +23,7 @@ public class DownloadManager {
         public let sampleRate: String
         public let channels: String
         public let fileSize: String
-        
+
         public init(formatId: String, fileExtension: String, description: String, bitrate: String = "", sampleRate: String = "", channels: String = "", fileSize: String = "") {
             self.formatId = formatId
             self.fileExtension = fileExtension
@@ -42,7 +34,7 @@ public class DownloadManager {
             self.fileSize = fileSize
         }
     }
-    
+
     public struct PlaylistInfo {
         public let id: String
         public let title: String
@@ -50,7 +42,7 @@ public class DownloadManager {
         public let uploader: String
         public let videoCount: Int
         public let items: [PlaylistItem]
-        
+
         public init(id: String, title: String, description: String, uploader: String, videoCount: Int, items: [PlaylistItem]) {
             self.id = id
             self.title = title
@@ -60,14 +52,14 @@ public class DownloadManager {
             self.items = items
         }
     }
-    
+
     public struct PlaylistItem {
         public let videoId: String
         public let title: String
         public let url: String
         public let duration: String
         public let thumbnailUrl: String
-        
+
         public init(videoId: String, title: String, url: String, duration: String, thumbnailUrl: String) {
             self.videoId = videoId
             self.title = title
@@ -76,14 +68,14 @@ public class DownloadManager {
             self.thumbnailUrl = thumbnailUrl
         }
     }
-    
+
     public struct PlaylistDownloadProgress {
         public let currentIndex: Int
         public let totalCount: Int
         public let currentTitle: String
         public let completed: Int
         public let failed: Int
-        
+
         public init(currentIndex: Int, totalCount: Int, currentTitle: String, completed: Int, failed: Int) {
             self.currentIndex = currentIndex
             self.totalCount = totalCount
@@ -92,7 +84,7 @@ public class DownloadManager {
             self.failed = failed
         }
     }
-    
+
     public enum DownloadError: Error {
         case formatFetchFailed
         case downloadFailed(String)
@@ -102,7 +94,7 @@ public class DownloadManager {
         case titleFetchFailed
         case playlistFetchFailed
         case playlistDownloadFailed(String)
-        
+
         var localizedDescription: String {
             switch self {
             case .formatFetchFailed:
@@ -124,7 +116,7 @@ public class DownloadManager {
             }
         }
     }
-    
+
     private struct ProcessResult {
         let terminationStatus: Int32
         let standardOutput: String
@@ -236,19 +228,19 @@ public class DownloadManager {
         let fileSize: String
         let codec: String
     }
-    
+
     private func checkFFmpegAvailability() throws -> String {
         let task = Process()
         task.launchPath = "/usr/bin/which"
         task.arguments = ["ffmpeg"]
-        
+
         let pipe = Pipe()
         task.standardOutput = pipe
-        
+
         do {
             task.launch()
             task.waitUntilExit()
-            
+
             if task.terminationStatus == 0 {
                 let data = pipe.fileHandleForReading.readDataToEndOfFile()
                 if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -257,36 +249,36 @@ public class DownloadManager {
                     return path
                 }
             }
-            
+
             let commonPaths = [
                 "/usr/local/bin/ffmpeg",
                 "/opt/homebrew/bin/ffmpeg"
             ]
-            
+
             for path in commonPaths where FileManager.default.fileExists(atPath: path) {
                 print(NSLocalizedString("Found ffmpeg path: %@", comment: "Log message when ffmpeg is found"), path)
                 return path
             }
-            
+
             throw DownloadError.ffmpegNotFound
         } catch {
             print(NSLocalizedString("Error checking ffmpeg: %@", comment: "Log message when checking ffmpeg fails"), error)
             throw DownloadError.ffmpegNotFound
         }
     }
-    
+
     private func checkYtDlpAvailability() throws -> String {
         let task = Process()
         task.launchPath = "/usr/bin/which"
         task.arguments = ["yt-dlp"]
-        
+
         let pipe = Pipe()
         task.standardOutput = pipe
-        
+
         do {
             task.launch()
             task.waitUntilExit()
-            
+
             if task.terminationStatus == 0 {
                 let data = pipe.fileHandleForReading.readDataToEndOfFile()
                 if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -295,24 +287,24 @@ public class DownloadManager {
                     return path
                 }
             }
-            
+
             let commonPaths = [
                 "/usr/local/bin/yt-dlp",
                 "/opt/homebrew/bin/yt-dlp"
             ]
-            
+
             for path in commonPaths where FileManager.default.fileExists(atPath: path) {
                 print(NSLocalizedString("Found yt-dlp path: %@", comment: "Log message when yt-dlp is found"), path)
                 return path
             }
-            
+
             throw DownloadError.ytDlpNotFound
         } catch {
             print(NSLocalizedString("Error checking yt-dlp: %@", comment: "Log message when checking yt-dlp fails"), error)
             throw DownloadError.ytDlpNotFound
         }
     }
-    
+
     private func getVideoTitle(from url: String, ytDlpPath: String) async throws -> String {
         do {
             let result = try await runCancellableProcess(
@@ -339,38 +331,38 @@ public class DownloadManager {
             throw DownloadError.titleFetchFailed
         }
     }
-    
+
     public func fetchAvailableFormats(from url: String) async throws -> [DownloadFormat] {
         print(NSLocalizedString("Getting available formats, URL: %@", comment: "Log message when fetching formats"), url)
-        
+
         guard URL(string: url) != nil else {
             throw DownloadError.invalidURL
         }
-        
+
         let ytDlpPath = try checkYtDlpAvailability()
         let ffmpegPath = try checkFFmpegAvailability()
-        
+
         let task = Process()
         task.launchPath = ytDlpPath
         task.arguments = [
             "--ffmpeg-location", ffmpegPath,
-            "-F", 
+            "-F",
             url
         ]
-        
+
         let pipe = Pipe()
         task.standardOutput = pipe
         let errorPipe = Pipe()
         task.standardError = errorPipe
-        
+
         do {
             task.launch()
             task.waitUntilExit()
-            
+
             if task.terminationStatus == 0 {
                 let data = pipe.fileHandleForReading.readDataToEndOfFile()
                 let output = String(data: data, encoding: .utf8) ?? ""
-                
+
                 return try parseFormatsFromOutput(output)
             } else {
                 let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
@@ -382,21 +374,21 @@ public class DownloadManager {
             throw error
         } catch {
             print(NSLocalizedString("Error getting formats: %@", comment: "Log message when getting formats fails"), error)
-            
+
             return createDefaultFormats()
         }
     }
-    
+
     private func createDefaultFormats() -> [DownloadFormat] {
         return [
             DownloadFormat(
-                formatId: "bestaudio", 
-                fileExtension: "mp3", 
+                formatId: "bestaudio",
+                fileExtension: "mp3",
                 description: NSLocalizedString("Best Quality (Auto Select)", comment: "Format description for best audio quality")
             ),
             DownloadFormat(
-                formatId: "140", 
-                fileExtension: "m4a", 
+                formatId: "140",
+                fileExtension: "m4a",
                 description: NSLocalizedString("M4A Audio (128kbps, 44kHz, stereo, 3.5MiB) [AAC]", comment: "Predefined format description"),
                 bitrate: "128kbps",
                 sampleRate: "44kHz",
@@ -404,8 +396,8 @@ public class DownloadManager {
                 fileSize: "3.5MiB"
             ),
             DownloadFormat(
-                formatId: "251", 
-                fileExtension: "webm", 
+                formatId: "251",
+                fileExtension: "webm",
                 description: NSLocalizedString("WebM Audio (160kbps, 48kHz, stereo, 3.2MiB) [Opus]", comment: "Predefined format description"),
                 bitrate: "160kbps",
                 sampleRate: "48kHz",
@@ -414,38 +406,38 @@ public class DownloadManager {
             )
         ]
     }
-    
+
     private func parseFormatsFromOutput(_ output: String) throws -> [DownloadFormat] {
         var formats: [DownloadFormat] = []
-        
+
         formats.append(DownloadFormat(
-            formatId: "bestaudio", 
-            fileExtension: "mp3", 
+            formatId: "bestaudio",
+            fileExtension: "mp3",
             description: NSLocalizedString("🎵 Best Quality (Auto Select)", comment: "Format description for best audio quality")
         ))
-        
+
         let lines = output.components(separatedBy: .newlines)
         for line in lines where line.contains("audio only") {
             if let format = parseAudioFormatLine(line) {
                 formats.append(format)
             }
         }
-        
+
         if formats.count <= 1 {
             formats.append(contentsOf: createDefaultFormats().dropFirst())
         }
-        
+
         return removeDuplicateFormats(formats)
     }
-    
+
     private func parseAudioFormatLine(_ line: String) -> DownloadFormat? {
         let components = line.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
         guard components.count >= 2 else { return nil }
-        
+
         let formatId = components[0]
-        
+
         var fileExtension = "mp3"
-        
+
         if line.contains("m4a") {
             fileExtension = "m4a"
         } else if line.contains("webm") {
@@ -453,12 +445,12 @@ public class DownloadManager {
         } else if line.contains("opus") {
             fileExtension = "opus"
         }
-        
+
         var bitrate = ""
         if let bitrateRange = line.range(of: "\\d+k", options: .regularExpression) {
             bitrate = String(line[bitrateRange])
         }
-        
+
         var sampleRate = ""
         if let sampleRateRange = line.range(of: "\\d+\\.?\\d*kHz|\\d+Hz|\\d+k\\s", options: .regularExpression) {
             sampleRate = String(line[sampleRateRange]).trimmingCharacters(in: .whitespaces)
@@ -467,7 +459,7 @@ public class DownloadManager {
         } else if line.contains("48k") {
             sampleRate = "48kHz"
         }
-        
+
         var channels = ""
         if line.contains("stereo") || line.contains("2.0") {
             channels = NSLocalizedString("stereo", comment: "Audio channel type")
@@ -478,12 +470,12 @@ public class DownloadManager {
         } else {
             channels = NSLocalizedString("stereo", comment: "Audio channel type")
         }
-        
+
         var fileSize = ""
         if let fileSizeRange = line.range(of: "\\d+\\.?\\d*[KMG]iB", options: .regularExpression) {
             fileSize = String(line[fileSizeRange])
         }
-        
+
         var codec = ""
         if line.contains("opus") {
             codec = "Opus"
@@ -494,7 +486,7 @@ public class DownloadManager {
         } else if line.contains("vorbis") {
             codec = "Vorbis"
         }
-        
+
         let properties = FormatDescriptionProperties(
             fileExtension: fileExtension,
             bitrate: bitrate,
@@ -503,12 +495,12 @@ public class DownloadManager {
             fileSize: fileSize,
             codec: codec
         )
-        
+
         let description = createFormatDescription(properties: properties)
-        
+
         return DownloadFormat(
-            formatId: formatId, 
-            fileExtension: fileExtension, 
+            formatId: formatId,
+            fileExtension: fileExtension,
             description: description,
             bitrate: bitrate,
             sampleRate: sampleRate,
@@ -516,73 +508,73 @@ public class DownloadManager {
             fileSize: fileSize
         )
     }
-    
+
     private func createFormatDescription(properties: FormatDescriptionProperties) -> String {
         var description = ""
-        
+
         if !properties.bitrate.isEmpty {
             description = String(format: NSLocalizedString("%@ Audio (%@", comment: "Format description with bitrate"), properties.fileExtension.uppercased(), properties.bitrate)
-            
+
             if !properties.sampleRate.isEmpty {
                 description += String(format: ", %@", properties.sampleRate)
             }
-            
+
             description += String(format: ", %@", properties.channels)
-            
+
             if !properties.fileSize.isEmpty {
                 description += String(format: ", %@", properties.fileSize)
             }
-            
+
             description += ")"
         } else {
             description = String(format: NSLocalizedString("%@ Audio", comment: "Format description without details"), properties.fileExtension.uppercased())
-            
+
             if !properties.sampleRate.isEmpty || !properties.channels.isEmpty || !properties.fileSize.isEmpty {
                 description += " ("
-                
+
                 if !properties.sampleRate.isEmpty {
                     description += properties.sampleRate
-                    
+
                     if !properties.channels.isEmpty || !properties.fileSize.isEmpty {
                         description += ", "
                     }
                 }
-                
+
                 if !properties.channels.isEmpty {
                     description += properties.channels
-                    
+
                     if !properties.fileSize.isEmpty {
                         description += ", "
                     }
                 }
-                
+
                 if !properties.fileSize.isEmpty {
                     description += properties.fileSize
                 }
-                
+
                 description += ")"
             }
         }
-        
+
         if !properties.codec.isEmpty {
             description += " [\(properties.codec)]"
         }
-        
+
         return description
     }
-    
+
     private func removeDuplicateFormats(_ formats: [DownloadFormat]) -> [DownloadFormat] {
         var uniqueFormats: [DownloadFormat] = []
         var seenDescriptions = Set<String>()
-        
+
         for format in formats where !seenDescriptions.contains(format.description) {
             uniqueFormats.append(format)
             seenDescriptions.insert(format.description)
         }
-        
+
         return uniqueFormats
     }
-    
+
     public func downloadAudio(from url: String, formatId: String) async throws {
         print(NSLocalizedString("Starting audio download, URL: %@, Format ID: %@", comment: "Log message when starting download"), url, formatId)
 
@@ -650,9 +642,8 @@ public class DownloadManager {
             throw DownloadError.downloadFailed(error.localizedDescription)
         }
     }
-    
-    // MARK: - Playlist Methods
-    
+
+
     public func isPlaylistURL(_ url: String) -> Bool {
         let playlistPatterns = [
             "list=",
@@ -662,12 +653,12 @@ public class DownloadManager {
             "youtube.com/playlist",
             "youtu.be/.*list="
         ]
-        
+
         return playlistPatterns.contains { pattern in
             url.range(of: pattern, options: .regularExpression) != nil
         }
     }
-    
+
     public func fetchPlaylistInfo(from url: String) async throws -> PlaylistInfo {
         print(NSLocalizedString("Getting playlist information, URL: %@", comment: "Log message when fetching playlist info"), url)
 
@@ -706,29 +697,27 @@ public class DownloadManager {
             throw DownloadError.playlistFetchFailed
         }
     }
-    
+
     private func parsePlaylistFromOutput(_ output: String, originalURL: String) throws -> PlaylistInfo {
         let lines = output.components(separatedBy: .newlines).filter { !$0.isEmpty }
         var items: [PlaylistItem] = []
         var playlistTitle = "Unknown Playlist"
         var playlistDescription = ""
         var uploader = "Unknown"
-        
+
         for line in lines {
             guard let data = line.data(using: .utf8) else { continue }
-            
+
             do {
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                    // Check if it's a playlist entry
                     if let entryType = json["_type"] as? String, entryType == "url" {
                         let videoId = json["id"] as? String ?? ""
                         let title = json["title"] as? String ?? "Unknown Title"
                         let videoUrl = json["url"] as? String ?? ""
                         let duration = json["duration_string"] as? String ?? ""
-                        
-                        // Build thumbnail URL
+
                         let thumbnailUrl = "https://img.youtube.com/vi/\(videoId)/default.jpg"
-                        
+
                         let item = PlaylistItem(
                             videoId: videoId,
                             title: title,
@@ -738,7 +727,6 @@ public class DownloadManager {
                         )
                         items.append(item)
                     }
-                    // Check if it contains playlist information
                     else if json["_type"] == nil || json["_type"] as? String == "playlist" {
                         if let title = json["title"] as? String {
                             playlistTitle = title
@@ -757,11 +745,11 @@ public class DownloadManager {
                 continue
             }
         }
-        
+
         if items.isEmpty {
             throw DownloadError.playlistFetchFailed
         }
-        
+
         return PlaylistInfo(
             id: extractPlaylistId(from: originalURL),
             title: playlistTitle,
@@ -771,16 +759,15 @@ public class DownloadManager {
             items: items
         )
     }
-    
+
     private func extractPlaylistId(from url: String) -> String {
-        // Extract playlist ID
         if let range = url.range(of: "list=([^&]+)", options: .regularExpression) {
             let listPart = String(url[range])
-            return String(listPart.dropFirst(5)) // Remove "list="
+            return String(listPart.dropFirst(5))
         }
         return "unknown"
     }
-    
+
     public func downloadPlaylist(
         from url: String,
         progressCallback: @escaping (PlaylistDownloadProgress) -> Void
@@ -839,4 +826,4 @@ public class DownloadManager {
 
         print(NSLocalizedString("Playlist download completed: %d successful, %d failed", comment: "Log message when playlist download completes"), completed, failed)
     }
-} 
+}

--- a/MacMusicPlayer/Managers/LaunchManager.swift
+++ b/MacMusicPlayer/Managers/LaunchManager.swift
@@ -1,28 +1,21 @@
-//
-//  LaunchManager.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
-
 import Foundation
 import ServiceManagement
 
 class LaunchManager: ObservableObject {
     private let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.seimotech.MacMusicPlayer"
-    
+
     @Published var launchAtLogin: Bool {
         didSet {
             setLaunchAtLogin(launchAtLogin)
             UserDefaults.standard.set(launchAtLogin, forKey: "LaunchAtLogin")
         }
     }
-    
+
     init() {
         self.launchAtLogin = UserDefaults.standard.object(forKey: "LaunchAtLogin") == nil ? true : UserDefaults.standard.bool(forKey: "LaunchAtLogin")
         setLaunchAtLogin(launchAtLogin)
     }
-    
+
     private func setLaunchAtLogin(_ enable: Bool) {
         if #available(macOS 13.0, *) {
             do {
@@ -42,4 +35,4 @@ class LaunchManager: ObservableObject {
             _ = SMLoginItemSetEnabled(bundleIdentifier as CFString, enable)
         }
     }
-} 
+}

--- a/MacMusicPlayer/Managers/LibraryManager.swift
+++ b/MacMusicPlayer/Managers/LibraryManager.swift
@@ -1,110 +1,88 @@
-//
-//  LibraryManager.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/03/21.
-//
-
 import Foundation
 import Combine
 
 class LibraryManager: ObservableObject {
     @Published var libraries: [MusicLibrary] = []
     @Published var currentLibrary: MusicLibrary?
-    
+
     init() {
         loadLibraries()
-        
-        // If no music library exists, try migrating existing single music library
+
         if libraries.isEmpty {
             migrateExistingSingleLibrary()
         }
-        
-        // If there are music libraries, load the most recently accessed one
+
         if let lastUsedId = UserDefaults.standard.string(forKey: "LastUsedLibraryID"),
            let uuid = UUID(uuidString: lastUsedId),
            let library = libraries.first(where: { $0.id == uuid }) {
             currentLibrary = library
         } else {
-            // Otherwise use the first one
             currentLibrary = libraries.first
         }
     }
-    
-    // Add new music library
+
     func addLibrary(name: String, path: String) {
         let newLibrary = MusicLibrary(
             name: name,
             path: path
         )
-        
+
         libraries.append(newLibrary)
         saveLibraries()
-        
-        // Automatically switch to newly added music library
+
         switchLibrary(id: newLibrary.id)
     }
-    
-    // Remove music library
+
     func removeLibrary(id: UUID) {
-        // Prevent deleting the last music library
         guard libraries.count > 1 else { return }
-        
+
         libraries.removeAll { $0.id == id }
-        
-        // If the deleted library is the current one, switch to the first one
+
         if currentLibrary?.id == id {
             currentLibrary = libraries.first
-            // Notify to refresh music library
             NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
         }
-        
+
         saveLibraries()
     }
-    
-    // Switch music library
+
     func switchLibrary(id: UUID) {
         guard currentLibrary?.id != id,
               let newLibrary = libraries.first(where: { $0.id == id }) else {
             return
         }
-        
-        // Update lastAccessed time
+
         var updatedLibrary = newLibrary
         updatedLibrary.lastAccessed = Date()
-        
+
         if let index = libraries.firstIndex(where: { $0.id == id }) {
             libraries[index] = updatedLibrary
         }
-        
+
         currentLibrary = updatedLibrary
-        
-        // Save last used library ID
+
         UserDefaults.standard.set(id.uuidString, forKey: "LastUsedLibraryID")
         saveLibraries()
-        
-        // Notify to refresh music library
+
         NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
     }
-    
-    // Rename music library
+
     func renameLibrary(id: UUID, newName: String) {
         guard let index = libraries.firstIndex(where: { $0.id == id }) else {
             return
         }
-        
+
         var updatedLibrary = libraries[index]
         updatedLibrary.name = newName
         libraries[index] = updatedLibrary
-        
+
         if currentLibrary?.id == id {
             currentLibrary = updatedLibrary
         }
-        
+
         saveLibraries()
     }
-    
-    // Save music library information
+
     func saveLibraries() {
         do {
             let data = try JSONEncoder().encode(libraries)
@@ -113,21 +91,19 @@ class LibraryManager: ObservableObject {
             print("Failed to save libraries: \(error)")
         }
     }
-    
-    // Load saved music library information
+
     func loadLibraries() {
         guard let data = UserDefaults.standard.data(forKey: "MusicLibraries") else {
             return
         }
-        
+
         do {
             libraries = try JSONDecoder().decode([MusicLibrary].self, from: data)
         } catch {
             print("Failed to load libraries: \(error)")
         }
     }
-    
-    // Migrate existing single music library
+
     private func migrateExistingSingleLibrary() {
         if let savedPath = UserDefaults.standard.string(forKey: "MusicFolderPath") {
             let defaultLibrary = MusicLibrary(
@@ -137,10 +113,10 @@ class LibraryManager: ObservableObject {
                 createdAt: Date(),
                 lastAccessed: Date()
             )
-            
+
             libraries.append(defaultLibrary)
             currentLibrary = defaultLibrary
             saveLibraries()
         }
     }
-} 
+}

--- a/MacMusicPlayer/Managers/PlayerManager.swift
+++ b/MacMusicPlayer/Managers/PlayerManager.swift
@@ -1,10 +1,3 @@
-//
-//  PlayerManager.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
-
 import Foundation
 import Combine
 import AppKit
@@ -23,16 +16,12 @@ class PlayerManager: NSObject, ObservableObject {
         }
     }
 
-    // New queue-based architecture
     private let queueController: QueuePlayerController
     private let playlistStore: PlaylistStore
 
-    /// Whether the playlist has any tracks
     var hasPlaylist: Bool { !playlistStore.isEmpty }
 
-    // Legacy currentIndex for backward compatibility during transition
     private var currentIndex = 0
-    // Direct volume control - no temporary caches
     var volume: Float {
         get { queueController.volume }
         set {
@@ -50,7 +39,6 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
     override init() {
-        // Initialize queue-based architecture first
         queueController = QueuePlayerController()
         playlistStore = PlaylistStore()
 
@@ -63,7 +51,6 @@ class PlayerManager: NSObject, ObservableObject {
 
         super.init()
 
-        // Initialize saved volume with default if first launch
         let savedVolume: Float
         if UserDefaults.standard.object(forKey: "SavedVolume") == nil {
             savedVolume = 0.3
@@ -72,19 +59,16 @@ class PlayerManager: NSObject, ObservableObject {
             savedVolume = UserDefaults.standard.float(forKey: "SavedVolume")
         }
 
-        // Wire up queue controller callbacks
         queueController.onTrackChanged = { [weak self] track in
             guard let self = self else { return }
             self.currentTrack = track
 
-            // Sync PlaylistStore currentIndex with queue controller track changes
             if let track = track,
                let trackIndex = self.playlistStore.tracks.firstIndex(where: { $0.id == track.id }) {
                 self.playlistStore.setCurrentIndex(trackIndex)
                 self.currentIndex = trackIndex
             }
 
-            // Ensure Now Playing metadata stays in sync for automatic transitions
             self.updateNowPlayingInfo()
         }
 
@@ -96,10 +80,8 @@ class PlayerManager: NSObject, ObservableObject {
             self?.handleAutomaticTrackCompletion(finishedTrack)
         }
 
-        // Set initial volume from saved preferences
         queueController.volume = savedVolume
 
-        // Listen for music library refresh notification
         NotificationCenter.default.addObserver(self,
                                             selector: #selector(refreshMusicLibrary),
                                             name: NSNotification.Name("RefreshMusicLibrary"),
@@ -109,7 +91,6 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
     private func loadSavedMusicFolder() {
-        // Do nothing, now controlled by LibraryManager
     }
 
     func requestMusicFolderAccess() {
@@ -119,12 +100,11 @@ class PlayerManager: NSObject, ObservableObject {
             openPanel.canChooseFiles = false
             openPanel.allowsMultipleSelection = false
             openPanel.prompt = NSLocalizedString("Select Music Folder", comment: "Open panel prompt for selecting music folder")
-            
+
             if openPanel.runModal() == .OK {
                 if let url = openPanel.url {
                     let name = url.lastPathComponent
-                    
-                    // Create new music library
+
                     NotificationCenter.default.post(
                         name: NSNotification.Name("AddNewLibrary"),
                         object: nil,
@@ -156,63 +136,52 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
     func loadLibrary(_ library: MusicLibrary) {
-        // Clear current queue and stop playback
         queueController.clearQueue()
         currentTrack = nil
         isPlaying = false
         currentIndex = 0
 
-        // Legacy playlist for backward compatibility during migration
         playlist = []
 
-        // Load music files from new music library
         loadTracksFromMusicFolder(URL(fileURLWithPath: library.path))
     }
-    
+
     func loadTracksFromMusicFolder(_ folderURL: URL) {
         let fileManager = FileManager.default
-        
-        // Get all contents of the folder
+
         guard let enumerator = fileManager.enumerator(at: folderURL,
                                                     includingPropertiesForKeys: [.isRegularFileKey],
                                                     options: [.skipsHiddenFiles, .skipsPackageDescendants]) else {
             print("Failed to enumerate folder contents")
             return
         }
-        
+
         var newPlaylist: [Track] = []
-        
+
         for case let fileURL as URL in enumerator {
-            // Check if file type is audio file
             if isAudioFile(fileURL) {
                 let fileName = fileURL.deletingPathExtension().lastPathComponent
-                
-                // Simple handling: use filename as title, split by " - " into artist and title if present
+
                 var title = fileName
                 var artist = NSLocalizedString("Unknown Artist", comment: "Default artist name when parsing filenames")
-                
+
                 if let range = fileName.range(of: " - ") {
                     artist = String(fileName[..<range.lowerBound]).trimmingCharacters(in: .whitespaces)
                     title = String(fileName[range.upperBound...]).trimmingCharacters(in: .whitespaces)
                 }
-                
+
                 let track = Track(id: UUID(), title: title, artist: artist, url: fileURL)
                 newPlaylist.append(track)
             }
         }
-        
-        // Update playlist
+
         DispatchQueue.main.async {
-            // Sort playlist by title
             let sortedTracks = newPlaylist.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
-            // Update PlaylistStore (new architecture)
             self.playlistStore.setTracks(sortedTracks)
 
-            // Legacy playlist for backward compatibility
             self.playlist = sortedTracks
 
-            // Set first track as current if available
             if !sortedTracks.isEmpty {
                 self.currentIndex = 0
                 self.currentTrack = sortedTracks[0]
@@ -222,12 +191,11 @@ class PlayerManager: NSObject, ObservableObject {
                 self.currentTrack = nil
                 self.currentIndex = 0
             }
-            
-            // Notify that playlist has been updated
+
             NotificationCenter.default.post(name: NSNotification.Name("PlaylistUpdated"), object: nil)
         }
     }
-    
+
     private func isAudioFile(_ url: URL) -> Bool {
         let audioExtensions = ["mp3", "m4a", "wav", "aac", "flac", "ogg", "aiff"]
         return audioExtensions.contains(url.pathExtension.lowercased())
@@ -239,7 +207,6 @@ class PlayerManager: NSObject, ObservableObject {
             return
         }
 
-        // Use queue controller for new architecture
         queueController.play()
 
         print(NSLocalizedString("Started playing", comment: "") + ": \(track.title)")
@@ -254,7 +221,6 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
     func stop() {
-        // Queue controller stop (pause + seek to 0, non-destructive)
         queueController.stop()
         updateNowPlayingInfo()
     }
@@ -273,7 +239,6 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
     func clearQueue() {
-        // Clear queue controller (destructive)
         queueController.clearQueue()
         currentTrack = nil
         isPlaying = false
@@ -284,40 +249,31 @@ class PlayerManager: NSObject, ObservableObject {
     func playNext() {
         guard !playlistStore.isEmpty else { return }
 
-        // Get next index based on play mode from PlaylistStore
         guard let nextIndex = playlistStore.nextIndex(for: playMode) else {
-            // No next track available (e.g., end of sequential playlist)
             return
         }
 
-        // Update PlaylistStore current index
         playlistStore.setCurrentIndex(nextIndex)
 
-        // Use queue controller advance or rebuild queue for complex modes
         switch playMode {
         case .sequential:
             if queueController.advanceToNext() {
-                // Successfully advanced in queue
                 currentIndex = nextIndex
             } else {
-                // End of queue, wrap around - rebuild queue
                 queueController.setQueue(playlistStore.tracks, startingAt: 0)
                 playlistStore.setCurrentIndex(0)
                 currentIndex = 0
                 queueController.play()
             }
         case .singleLoop:
-            // Restart current track
             queueController.stop()
             queueController.play()
         case .random:
-            // Rebuild queue starting at random index
             queueController.setQueue(playlistStore.tracks, startingAt: nextIndex)
             currentIndex = nextIndex
             queueController.play()
         }
 
-        // Legacy update for backward compatibility
         currentTrack = playlistStore.currentTrack
 
         updateNowPlayingInfo()
@@ -330,16 +286,13 @@ class PlayerManager: NSObject, ObservableObject {
         case .sequential, .random:
             guard let previousIndex = playlistStore.previousIndex() else { return }
 
-            // Rebuild queue for previous track (AVQueuePlayer limitation)
             queueController.setQueue(playlistStore.tracks, startingAt: previousIndex)
             playlistStore.setCurrentIndex(previousIndex)
             currentIndex = previousIndex
             queueController.play()
 
-            // Legacy update
             currentTrack = playlistStore.currentTrack
         case .singleLoop:
-            // Restart current track
             queueController.stop()
             queueController.play()
         }
@@ -350,7 +303,6 @@ class PlayerManager: NSObject, ObservableObject {
 
     @MainActor
     @objc func refreshMusicLibrary() {
-        // Simply reload the current library, same as startup
         if let library = (NSApplication.shared.delegate as? AppDelegate)?.libraryManager.currentLibrary {
             loadLibrary(library)
         } else {
@@ -359,11 +311,9 @@ class PlayerManager: NSObject, ObservableObject {
     }
 
 
-    /// Randomly select and play a track - "Feeling Lucky" feature
     func feelingLucky() {
         guard !playlistStore.isEmpty else { return }
 
-        // Generate random index, avoiding current track for variety
         var randomIndex = Int.random(in: 0..<playlistStore.count)
         if playlistStore.count > 1 {
             while randomIndex == playlistStore.currentIndex {
@@ -385,7 +335,6 @@ class PlayerManager: NSObject, ObservableObject {
             else { return }
 
             if finishedIndex == playlistStore.count - 1 {
-                // Last track finished – rebuild queue from the top to loop
                 let nextIndex = (finishedIndex + 1) % playlistStore.count
                 queueController.setQueue(playlistStore.tracks, startingAt: nextIndex)
                 queueController.play()
@@ -407,16 +356,13 @@ class PlayerManager: NSObject, ObservableObject {
             updateNowPlayingInfo()
 
         case .random:
-            // Pick a truly random next track and rebuild queue
             guard let nextIndex = playlistStore.nextIndex(for: playMode) else { return }
 
-            // Rebuild queue starting from the random track
             queueController.setQueue(playlistStore.tracks, startingAt: nextIndex)
             playlistStore.setCurrentIndex(nextIndex)
             currentIndex = nextIndex
             queueController.play()
 
-            // Update UI state
             currentTrack = playlistStore.currentTrack
             updateNowPlayingInfo()
         }

--- a/MacMusicPlayer/Managers/PlaylistStore.swift
+++ b/MacMusicPlayer/Managers/PlaylistStore.swift
@@ -1,10 +1,3 @@
-//
-//  PlaylistStore.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/23.
-//
-
 import Foundation
 
 enum PlayMode: String {
@@ -17,7 +10,6 @@ enum PlayMode: String {
     }
 }
 
-/// Owns authoritative track ordering (source of truth)
 class PlaylistStore: ObservableObject {
     @Published private(set) var tracks: [Track] = []
     @Published private(set) var currentIndex: Int = 0

--- a/MacMusicPlayer/Managers/QueuePlayerController.swift
+++ b/MacMusicPlayer/Managers/QueuePlayerController.swift
@@ -1,10 +1,3 @@
-//
-//  QueuePlayerController.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/23.
-//
-
 import Foundation
 import AVFoundation
 
@@ -99,7 +92,6 @@ class QueuePlayerController: NSObject, PlaybackControlling {
         currentTrackIndex = index
     }
 
-    // MARK: - PlaybackControlling Implementation
 
     func play() {
         queuePlayer.play()

--- a/MacMusicPlayer/Managers/SleepManager.swift
+++ b/MacMusicPlayer/Managers/SleepManager.swift
@@ -1,10 +1,3 @@
-//
-//  SleepManager.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/10/01.
-//
-
 import Foundation
 import IOKit.pwr_mgt
 
@@ -16,10 +9,10 @@ class SleepManager: ObservableObject {
             UserDefaults.standard.synchronize()
         }
     }
-    
+
     private var displayAssertionID: IOPMAssertionID = 0
     private var systemAssertionID: IOPMAssertionID = 0
-    
+
     init() {
         if UserDefaults.standard.object(forKey: "PreventSleepEnabled") != nil {
             self.preventSleep = UserDefaults.standard.bool(forKey: "PreventSleepEnabled")
@@ -27,14 +20,14 @@ class SleepManager: ObservableObject {
             self.preventSleep = true
             UserDefaults.standard.set(true, forKey: "PreventSleepEnabled")
         }
-        
+
         updateSleepAssertion()
     }
-    
+
     deinit {
         releaseAssertion()
     }
-    
+
     private func updateSleepAssertion() {
         if preventSleep {
             createAssertion()
@@ -42,47 +35,47 @@ class SleepManager: ObservableObject {
             releaseAssertion()
         }
     }
-    
+
     func cleanupResourcesOnly() {
         releaseAssertion()
     }
-    
+
     private func createAssertion() {
         if displayAssertionID != 0 || systemAssertionID != 0 {
             releaseAssertion()
         }
-        
+
         let displayResult = IOPMAssertionCreateWithName(
             kIOPMAssertionTypePreventUserIdleDisplaySleep as CFString,
             IOPMAssertionLevel(kIOPMAssertionLevelOn),
             "MacMusicPlayer is preventing display sleep" as CFString,
             &displayAssertionID
         )
-        
+
         if displayResult != kIOReturnSuccess {
             print("Failed to create display sleep assertion: \(displayResult)")
             displayAssertionID = 0
         }
-        
+
         let systemResult = IOPMAssertionCreateWithName(
             kIOPMAssertionTypePreventUserIdleSystemSleep as CFString,
             IOPMAssertionLevel(kIOPMAssertionLevelOn),
             "MacMusicPlayer is preventing system sleep" as CFString,
             &systemAssertionID
         )
-        
+
         if systemResult != kIOReturnSuccess {
             print("Failed to create system sleep assertion: \(systemResult)")
             systemAssertionID = 0
         }
     }
-    
+
     private func releaseAssertion() {
         if displayAssertionID != 0 {
             IOPMAssertionRelease(displayAssertionID)
             displayAssertionID = 0
         }
-        
+
         if systemAssertionID != 0 {
             IOPMAssertionRelease(systemAssertionID)
             systemAssertionID = 0

--- a/MacMusicPlayer/Managers/YTSearchManager.swift
+++ b/MacMusicPlayer/Managers/YTSearchManager.swift
@@ -1,18 +1,10 @@
-//
-//  YTSearchManager.swift
-//  MacMusicPlayer
-//
-//  Created by samzong<samzong.lu@gmail.com>
-//
-
 import Foundation
 
 class YTSearchManager {
     static let shared = YTSearchManager()
-    
+
     private let configManager = ConfigManager.shared
-    
-    // Search result model
+
     struct SearchResult: Codable {
         struct VideoItem: Codable {
             let videoId: String
@@ -21,56 +13,49 @@ class YTSearchManager {
             let thumbnailUrl: String
             let platform: String
         }
-        
+
         let items: [VideoItem]
         let nextPageToken: String?
         let totalResults: Int
     }
-    
+
     private init() {}
-    
-    // Search method
+
     func search(keyword: String, pageToken: String? = nil, completion: @escaping (Result<SearchResult, Error>) -> Void) {
-        // Check if configuration is valid
         guard configManager.isConfigValid else {
             let error = NSError(domain: "YTSearchManager", code: 1001, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("API configuration not completed", comment: "")])
             completion(.failure(error))
             return
         }
-        
-        // Ensure API URL is not empty and handle trailing slash
+
         let apiUrl = configManager.apiUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !apiUrl.isEmpty else {
             let error = NSError(domain: "YTSearchManager", code: 1002, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("API URL not configured", comment: "")])
             completion(.failure(error))
             return
         }
-        
-        // Build URL
+
         var urlComponents = URLComponents(string: "\(apiUrl)/search")
         let queryItems = [
             URLQueryItem(name: "platform", value: "youtube"),
             URLQueryItem(name: "q", value: keyword),
             pageToken != nil ? URLQueryItem(name: "pageToken", value: pageToken) : nil
         ].compactMap { $0 }
-        
+
         urlComponents?.queryItems = queryItems
-        
+
         guard let url = urlComponents?.url else {
             let error = NSError(domain: "YTSearchManager", code: 1002, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Invalid URL", comment: "")])
             completion(.failure(error))
             return
         }
-        
-        // Log full request information
+
         print("YTSearchManager - Send request: URL: \(url.absoluteString), PageToken: \(pageToken ?? "nil")")
-        
-        // Create request
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.addValue("Bearer \(configManager.apiKey)", forHTTPHeaderField: "Authorization")
-        
-        // Send request
+
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
             if let error = error {
                 DispatchQueue.main.async {
@@ -78,7 +63,7 @@ class YTSearchManager {
                 }
                 return
             }
-            
+
             guard let data = data else {
                 let error = NSError(domain: "YTSearchManager", code: 1003, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("No data received", comment: "")])
                 DispatchQueue.main.async {
@@ -86,8 +71,7 @@ class YTSearchManager {
                 }
                 return
             }
-            
-            // Check HTTP status code
+
             if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
                 let errorMessage = String(format: NSLocalizedString("Server Error: %@", comment: "Server error message"), String(httpResponse.statusCode))
                 let error = NSError(domain: "YTSearchManager", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: errorMessage])
@@ -96,31 +80,28 @@ class YTSearchManager {
                 }
                 return
             }
-            
-            // Parse JSON
+
             do {
                 let decoder = JSONDecoder()
                 let result = try decoder.decode(SearchResult.self, from: data)
-                
-                // Log response information
+
                 print("YTSearchManager -Response received: Number of items: \(result.items.count), NextPageToken: \(result.nextPageToken ?? "nil"), Total results: \(result.totalResults)")
-                
+
                 DispatchQueue.main.async {
                     completion(.success(result))
                 }
             } catch {
                 print("YTSearchManager - JSON parsing error: \(error)")
-                // Print raw data content for debugging
                 if let jsonString = String(data: data, encoding: .utf8) {
                     print("YTSearchManager - Original JSON: \(jsonString)")
                 }
-                
+
                 DispatchQueue.main.async {
                     completion(.failure(error))
                 }
             }
         }
-        
+
         task.resume()
     }
-} 
+}

--- a/MacMusicPlayer/Models/MusicLibrary.swift
+++ b/MacMusicPlayer/Models/MusicLibrary.swift
@@ -1,10 +1,3 @@
-//
-//  MusicLibrary.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/03/21.
-//
-
 import Foundation
 
 struct MusicLibrary: Identifiable, Codable {
@@ -13,7 +6,7 @@ struct MusicLibrary: Identifiable, Codable {
     var path: String
     var createdAt: Date
     var lastAccessed: Date
-    
+
     init(id: UUID = UUID(), name: String, path: String, createdAt: Date = Date(), lastAccessed: Date = Date()) {
         self.id = id
         self.name = name
@@ -21,4 +14,4 @@ struct MusicLibrary: Identifiable, Codable {
         self.createdAt = createdAt
         self.lastAccessed = lastAccessed
     }
-} 
+}

--- a/MacMusicPlayer/Models/Track.swift
+++ b/MacMusicPlayer/Models/Track.swift
@@ -1,10 +1,3 @@
-//
-//  Track.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
-
 import Foundation
 
 struct Track: Identifiable {

--- a/MacMusicPlayer/Protocols/PlaybackControlling.swift
+++ b/MacMusicPlayer/Protocols/PlaybackControlling.swift
@@ -1,10 +1,3 @@
-//
-//  PlaybackControlling.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/23.
-//
-
 import Foundation
 import AVFoundation
 

--- a/MacMusicPlayer/Views/CustomTableRowView.swift
+++ b/MacMusicPlayer/Views/CustomTableRowView.swift
@@ -1,24 +1,15 @@
-//
-//  CustomTableRowView.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/18.
-//
-
 import Cocoa
 
-/// Custom table row view with separator line and hover effects
 class CustomTableRowView: NSTableRowView {
     override func drawSelection(in dirtyRect: NSRect) {
         if self.selectionHighlightStyle != .none {
             super.drawSelection(in: dirtyRect)
         }
     }
-    
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-        
-        // Draw bottom separator line
+
         let bottomLine = NSBezierPath()
         NSColor.separatorColor.withAlphaComponent(0.2).setStroke()
         bottomLine.lineWidth = 0.5
@@ -26,34 +17,32 @@ class CustomTableRowView: NSTableRowView {
         bottomLine.line(to: NSPoint(x: self.bounds.width - 10, y: 0))
         bottomLine.stroke()
     }
-    
-    // Add mouse hover effect
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        
+
         for trackingArea in self.trackingAreas {
             self.removeTrackingArea(trackingArea)
         }
-        
+
         let options: NSTrackingArea.Options = [.mouseEnteredAndExited, .activeAlways]
         let trackingArea = NSTrackingArea(rect: self.bounds, options: options, owner: self, userInfo: nil)
         self.addTrackingArea(trackingArea)
     }
-    
+
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
         self.wantsLayer = true
-        
-        // Use a faded version of system accent color for hover effect
+
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.2
             self.animator().layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.1).cgColor
         })
     }
-    
+
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
-        
+
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.2
             self.animator().layer?.backgroundColor = NSColor.clear.cgColor

--- a/MacMusicPlayer/Views/SimpleSongPickerWindow.swift
+++ b/MacMusicPlayer/Views/SimpleSongPickerWindow.swift
@@ -1,10 +1,3 @@
-//
-//  SimpleSongPickerWindow.swift
-//  MacMusicPlayer
-//
-//  Created by X on 2024/09/24.
-//
-
 import Cocoa
 import Combine
 
@@ -37,8 +30,7 @@ class SimpleSongPickerWindow: NSPanel {
         setupWindow()
         setupViews()
         loadTracks()
-        
-        // Listen for playlist updates via Combine
+
         if let playerManager = self.playerManager {
             playlistCancellable = playerManager.$playlist
                 .receive(on: DispatchQueue.main)
@@ -67,7 +59,6 @@ class SimpleSongPickerWindow: NSPanel {
     private func setupViews() {
         guard let contentView = contentView else { return }
 
-        // Background view with rounded corners and visual effect for dark mode support
         backgroundView = NSVisualEffectView()
         backgroundView.material = .sidebar
         backgroundView.blendingMode = .behindWindow
@@ -84,7 +75,6 @@ class SimpleSongPickerWindow: NSPanel {
             backgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
 
-        // Search field
         searchField = NSSearchField()
         searchField.placeholderString = NSLocalizedString(
             "search_songs_placeholder",
@@ -94,7 +84,6 @@ class SimpleSongPickerWindow: NSPanel {
         searchField.translatesAutoresizingMaskIntoConstraints = false
         backgroundView.addSubview(searchField)
 
-        // Table view in scroll view
         let scrollView = NSScrollView()
         scrollView.hasVerticalScroller = false
         scrollView.hasHorizontalScroller = false
@@ -120,14 +109,12 @@ class SimpleSongPickerWindow: NSPanel {
 
         scrollView.documentView = tableView
 
-        // Status label
         statusLabel = NSTextField(labelWithString: "Press Enter to play, Esc to Close")
         statusLabel.font = NSFont.systemFont(ofSize: 11)
         statusLabel.textColor = .secondaryLabelColor
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         backgroundView.addSubview(statusLabel)
 
-        // Layout
         NSLayoutConstraint.activate([
             searchField.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 20),
             searchField.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor, constant: 20),
@@ -164,7 +151,6 @@ class SimpleSongPickerWindow: NSPanel {
     }
 
     private func filterTracks() {
-        // Cancel any pending filter operation
         filterWorkItem?.cancel()
 
         let searchText = searchField.stringValue.lowercased()
@@ -182,7 +168,6 @@ class SimpleSongPickerWindow: NSPanel {
                 }
             }
 
-            // Update UI on main thread
             DispatchQueue.main.async { [weak self] in
                 guard let self = self, self.filterWorkItem?.isCancelled == false else { return }
 
@@ -199,7 +184,6 @@ class SimpleSongPickerWindow: NSPanel {
 
         filterWorkItem = workItem
 
-        // Debounce: wait 150ms before filtering to avoid filtering on every keystroke
         DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 0.15, execute: workItem)
     }
 
@@ -245,13 +229,13 @@ class SimpleSongPickerWindow: NSPanel {
 
     override func keyDown(with event: NSEvent) {
         switch event.keyCode {
-        case 36, 76: // Return or Enter
+        case 36, 76:
             playSelectedTrack()
 
-        case 53: // Escape
+        case 53:
             close()
 
-        case 49: // Space
+        case 49:
             if searchField.currentEditor() == nil {
                 guard let playerManager = playerManager,
                       let selectedRow = tableView.selectedRow >= 0 ? tableView.selectedRow : nil,
@@ -265,7 +249,6 @@ class SimpleSongPickerWindow: NSPanel {
                         playerManager.play()
                     }
                 } else {
-                    // Play the selected track without closing the window
                     if let allTrackIndex = findAllTrackIndex(for: selectedRow) {
                         playerManager.playTrack(at: allTrackIndex)
                         tableView.reloadData()
@@ -288,14 +271,12 @@ class SimpleSongPickerWindow: NSPanel {
     }
 }
 
-// MARK: - NSTableViewDataSource
 extension SimpleSongPickerWindow: NSTableViewDataSource {
     func numberOfRows(in tableView: NSTableView) -> Int {
         return filteredTracks.count
     }
 }
 
-// MARK: - NSTableViewDelegate
 extension SimpleSongPickerWindow: NSTableViewDelegate {
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         let identifier = NSUserInterfaceItemIdentifier("TrackCell")
@@ -343,13 +324,11 @@ extension SimpleSongPickerWindow: NSTableViewDelegate {
     func tableView(_ tableView: NSTableView,
                    shouldTypeSelectFor event: NSEvent,
                    withCurrentSearch searchString: String?) -> Bool {
-        // Disable AppKit type-select to avoid scanning the full playlist and keep text input in the search field.
         return false
     }
 
 }
 
-// MARK: - NSSearchFieldDelegate
 extension SimpleSongPickerWindow: NSSearchFieldDelegate {
     func controlTextDidChange(_ obj: Notification) {
         filterTracks()

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,192 @@
+# Redundancy Review TODO
+
+## P1 Dependency Detection Is Duplicated And Inconsistent
+
+- `MacMusicPlayer/Controllers/DownloadViewController.swift:476` checks `yt-dlp` and `ffmpeg` in the UI layer.
+- `MacMusicPlayer/Managers/DownloadManager.swift:240` and `MacMusicPlayer/Managers/DownloadManager.swift:278` check the same dependencies again in the download layer.
+- The UI check adds `/opt/local/bin` to `PATH`, while `DownloadManager` only falls back to `/usr/local/bin` and `/opt/homebrew/bin`.
+- Risk: the UI can report a dependency as installed while the actual download path still fails.
+- Preferred fix: make `DownloadManager` the single dependency status source and let the UI render that status.
+
+## P2 RefreshMusicLibrary Is Posted Multiple Times
+
+- `MacMusicPlayer/Managers/DownloadManager.swift:638` posts `RefreshMusicLibrary` after a successful audio download.
+- `MacMusicPlayer/Controllers/DownloadViewController.swift:1221`, `:1951`, and `:1997` post the same notification again from the UI.
+- Risk: single downloads can refresh twice; playlist downloads can refresh once per item and again at the end.
+- Preferred fix: choose one notification owner. The download layer is the better owner if every successful write should refresh the library.
+
+## P2 PlayerManager Keeps A Write-Only Legacy currentIndex
+
+- `MacMusicPlayer/Managers/PlayerManager.swift:33` defines a legacy `currentIndex`.
+- The field is assigned in many playback paths, but actual reads use `PlaylistStore.currentIndex`.
+- Preferred fix: remove `PlayerManager.currentIndex` and the assignments that only mirror `PlaylistStore`.
+
+## P2 loadSavedMusicFolder Is An Empty Compatibility Stub
+
+- `MacMusicPlayer/Managers/PlayerManager.swift:111` defines `loadSavedMusicFolder()` as an empty method.
+- It is still called during init and refresh fallback.
+- Preferred fix: remove the empty method and replace callers with explicit no-op behavior or a real fallback, depending on the intended migration policy.
+
+## P3 PlaybackControlling Has No Current Abstraction Value
+
+- `MacMusicPlayer/Protocols/PlaybackControlling.swift:11` defines `PlaybackControlling`.
+- `QueuePlayerController` is the only implementation.
+- `PlayerManager` stores `QueuePlayerController` directly rather than the protocol type.
+- Preferred fix: delete the protocol unless a real mock/test/plugin boundary is introduced.
+
+## P3 Unused Private Method
+
+- `MacMusicPlayer/Controllers/DownloadViewController.swift:1249` defines `showAlert(message:)`.
+- No call sites were found.
+- Preferred fix: delete the method.
+
+## P3 DownloadViewController Has Copy-Paste UI Helpers
+
+- Dependency preflight is duplicated around `MacMusicPlayer/Controllers/DownloadViewController.swift:982` and `:1082`.
+- Window expansion frame logic is duplicated around `:819`, `:1024`, and `:1118`.
+- Download button restoration is repeated across several success, failure, and stop paths.
+- Preferred fix: extract only small helpers for repeated state transitions; do not split the whole controller without a concrete boundary.
+
+## Not Redundant
+
+- `CustomTableRowView`, `SimpleSongPickerWindow`, `Track`, and `MusicLibrary` have real call chains.
+- `ConfigManager.resetConfig()` is used by the Settings reset button.
+- SwiftLint `unused_import` and `duplicate_imports` checks did not report import-level redundancy.
+
+## Verification Already Run
+
+- `xcodebuild -list -project MacMusicPlayer.xcodeproj`
+- `swiftlint lint --only-rule unused_import --only-rule duplicate_imports --quiet --no-cache`
+- Symbol/text reference checks for the items above.
+- Mechanical duplicate-window scan over Swift sources.
+
+## Not Yet Run
+
+- Full app build.
+- Runtime UI verification.
+- Behavior tests. No test target was detected.
+
+# Code Quality Review
+
+## Verification Run For This Review
+
+- `xcodebuild -project MacMusicPlayer.xcodeproj -scheme MacMusicPlayer -configuration Debug -destination 'platform=macOS' build -quiet`
+  - Result: build succeeded.
+  - Xcode warning: scheme/destination metadata is odd; Xcode reports an empty supported platform list and picks one of multiple matching macOS destinations.
+- `swiftlint lint --quiet --no-cache --reporter json`
+  - Result: failed with 190 violations.
+  - Severity: 6 errors, 184 warnings.
+  - Top rules: `line_length` 128, `missing_docs` 38, `vertical_whitespace` 7, `file_header` 4.
+  - Most affected files: `DownloadManager.swift` 74, `DownloadViewController.swift` 47, `StatusMenuController.swift` 30.
+
+## High-Value Quality Findings
+
+### P1 DownloadViewController Is A God Object
+
+- `MacMusicPlayer/Controllers/DownloadViewController.swift` has 2008 lines.
+- SwiftLint reports `file_length` and `type_body_length` errors.
+- It owns UI construction, dependency detection, search state, playlist state, table rendering, thumbnail loading, download task state, pagination, error-copy UI, and direct app delegate coordination.
+- This is the main maintainability problem. The correct fix is not a huge rewrite; split only the stateful seams that already exist:
+  - dependency status owned by `DownloadManager`;
+  - download button/progress state helpers;
+  - table cell factory helpers;
+  - search/playlist mode state.
+
+### P1 Synchronous Work Can Block Threads Or Produce Stale UI
+
+- `DownloadManager.fetchAvailableFormats` uses `Process.launch()`, `waitUntilExit()`, and reads pipes after process exit.
+- `DownloadViewController` still has separate synchronous dependency-check `Process` calls.
+- `DownloadViewController` loads thumbnails with `Data(contentsOf:)` on a global queue and sets the image later without verifying that the reused table cell still represents the same row.
+- Risk: stale thumbnails in reused cells, poor cancellation behavior, and fragile process I/O.
+- Preferred fix: centralize process execution through one async helper and use URLSession or an image loader with cell identity checks for thumbnails.
+
+### P1 Playback Queue State Has Conflicting Sources Of Truth
+
+- `PlayerManager` mirrors state across `playlist`, `currentTrack`, `isPlaying`, `currentIndex`, `PlaylistStore`, and `QueuePlayerController`.
+- `currentIndex` is already marked legacy and is write-only.
+- `currentTrack` is updated manually in several paths and also from queue callbacks.
+- Risk: UI and Now Playing metadata can drift from the actual `AVQueuePlayer` item after automatic transitions or queue rebuilds.
+- Preferred fix: remove the dead `currentIndex` first, then define whether `PlaylistStore` or `QueuePlayerController` owns current-track truth.
+
+### P2 Stringly-Typed Notifications Are A Low-Grade Architecture
+
+- Notification names are raw string literals such as `TrackChanged`, `PlaybackStateChanged`, `PlaylistUpdated`, `RefreshMusicLibrary`, `ConfigUpdated`, and `AddNewLibrary`.
+- These are spread across app delegate, managers, and controllers.
+- Risk: typo-prone, no discoverable contract, hard to audit payloads.
+- Preferred fix: introduce typed `Notification.Name` constants in one small namespace, not a new event bus.
+
+### P2 Public API Is Overused Inside An App Target
+
+- `DownloadManager` and nested DTOs are declared `public` even though this is a single app target, not a framework boundary.
+- SwiftLint's 38 `missing_docs` warnings mostly come from that unnecessary `public` surface.
+- Preferred fix: make these declarations internal unless there is a real module boundary.
+
+### P2 Old-Style KVO In QueuePlayerController
+
+- `QueuePlayerController` uses string key-path KVO for `rate` and `currentItem`.
+- SwiftLint reports `block_based_kvo`.
+- Preferred fix: use block-based key-path observation and store `NSKeyValueObservation` tokens.
+
+### P2 Logging Is Mostly Print Statements
+
+- `DownloadManager` has 26 `print` calls; `YTSearchManager` logs full URLs and raw JSON on parse errors.
+- Risk: noisy production logs and accidental leakage of URLs/API behavior.
+- Preferred fix: use `Logger` with subsystem/category and avoid dumping raw server responses unless behind debug-only logic.
+
+### P2 Localization Is Broad But Slightly Inconsistent
+
+- Swift sources contain 140 unique `NSLocalizedString` keys.
+- Each `Localizable.strings` file has 149 keys, but each locale is missing 5 keys used by Swift and has 14 extra keys.
+- Missing keys include `🎵 Best Quality (Auto Select)`, `Failed to get playlist info: %@`, `Error getting playlist info: %@`, `Dev: %@`, and `Version %@`.
+- Preferred fix: reconcile keys per locale; avoid emoji in localization keys.
+
+### P3 Force Unwraps In Table Cell Construction
+
+- `SimpleSongPickerWindow` and `DownloadViewController` use `cellView!` / `cell!` while constructing table cells.
+- These are probably safe in the current local branch because the cell is just allocated above, but the style is brittle and unnecessary.
+- Preferred fix: bind the newly created cell to a non-optional local before installing constraints.
+
+### P3 Info.plist Has Suspicious Residual Keys
+
+- `UIBackgroundModes` is an iOS-style key in a macOS app.
+- `CFBundleDocumentTypes` contains an almost empty document type.
+- `NSServices` contains an empty dictionary.
+- `SMPrivilegedExecutables` references the app bundle id itself.
+- These may be harmless, but they look like copied template residue unless a packaging/signing workflow requires them.
+
+## Low-Level / Garbage-Code Smells
+
+- Obvious narration comments repeat the next line, especially in `DownloadViewController`, `PlayerManager`, and `LibraryManager`.
+- Multiple comments say `legacy`, `new architecture`, `transition`, or `Do nothing`; the transition was never finished.
+- Manual UI layout creates the same `NSTextField` and container boilerplate repeatedly.
+- Error handling often collapses detailed failures into generic user messages, while still printing raw details.
+- The app uses singleton/global access (`DownloadManager.shared`, `ConfigManager.shared`, `NSApp.delegate`) in places where explicit dependencies already exist.
+- `URL(string:) != nil` is used as validation for downloader URLs; that is too weak for user-facing URL validation.
+
+## AI-Authorship Heuristic
+
+- Probability this codebase has substantial AI-assisted generation: high, roughly 75-85%.
+- This is not proof and cannot identify the author. It is a style heuristic.
+- Evidence raising the probability:
+  - excessive explanatory comments for obvious code;
+  - generic phase comments such as "New queue-based architecture", "Legacy update", "Use Task to execute asynchronous operations";
+  - large controller with many features appended sequentially instead of cohesive boundaries;
+  - repetitive localized strings, button styling, and dispatch-to-main blocks;
+  - broad `public` access in an app target;
+  - template-like file headers with `Created by X`;
+  - multiple unfinished migration markers.
+- Evidence lowering the probability:
+  - the app builds;
+  - core playback/download flows are real, not mock placeholders;
+  - there are domain-specific integrations with `yt-dlp`, `ffmpeg`, `AVQueuePlayer`, status menu, sleep assertions, and localization files.
+- Best read: likely human-directed code with significant AI-assisted expansion and insufficient cleanup.
+
+## Suggested Cleanup Order
+
+1. Make `DownloadManager` the single dependency/status source and delete UI-side duplicate dependency probing.
+2. Remove duplicate `RefreshMusicLibrary` posts from UI after `DownloadManager.downloadAudio`.
+3. Delete `PlayerManager.currentIndex`, `loadSavedMusicFolder()`, `showAlert(message:)`, and `PlaybackControlling` if no test boundary is planned.
+4. Replace raw notification strings with centralized `Notification.Name` constants.
+5. Convert `QueuePlayerController` to block-based KVO.
+6. Extract only small `DownloadViewController` helpers for repeated progress/button/window/table-cell logic.
+7. Reconcile localization keys and remove suspicious Info.plist residue only after confirming packaging requirements.


### PR DESCRIPTION
### What's changed?

- Removed Swift source comments and file headers from the app code while preserving string literal URL and regex content.
- Added todo.md with the requested redundancy, code-quality, and AI-likelihood review notes.

### Why

- Aligns the source tree with the no-code-comments cleanup request and keeps the review findings tracked in the repository.

## Considered and deferred

- MacMusicPlayer/Models/Track.swift:1 [BOT-NIT]: SwiftLint file_header still warns after removing headers; restoring comment headers would violate the no-code-comments scope, and PR CI uses make dmg/check-arch, which passed.