### PR TITLE
[Feat] Add selected playlist downloads

### DIFF
--- a/MacMusicPlayer/Controllers/DownloadViewController.swift
+++ b/MacMusicPlayer/Controllers/DownloadViewController.swift
@@ -34,10 +34,16 @@ class DownloadViewController: NSViewController {
     private var libraryManager: LibraryManager!
 
     private var currentPlaylist: DownloadManager.PlaylistInfo?
+    private var currentPlaylistURL: String?
+    private var activePlaylistLoadID: UUID?
+    private var activePlaylistLoadURL: String?
+    private var selectedPlaylistRows = Set<Int>()
     private var isPlaylistMode: Bool = false
     private var isDownloading: Bool = false
     private var downloadTask: Task<Void, Never>?
     private weak var activeDownloadButton: NSButton?
+    private let maxConcurrentPlaylistDownloads = 3
+    private let actionButtonWidth: CGFloat = 116
 
     private var searchResults: [YTSearchManager.SearchResult.VideoItem] = []
     private var isSearchMode: Bool = false
@@ -135,7 +141,7 @@ class DownloadViewController: NSViewController {
         NSLayoutConstraint.activate([
             urlTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             urlTextField.leadingAnchor.constraint(equalTo: libraryPopup.trailingAnchor, constant: 8),
-            urlTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -110),
+            urlTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -(actionButtonWidth + 28)),
             urlTextField.heightAnchor.constraint(equalToConstant: 28)
         ])
     }
@@ -147,14 +153,7 @@ class DownloadViewController: NSViewController {
         detectButton.target = self
         detectButton.action = #selector(detectOrSearch)
         detectButton.font = NSFont.systemFont(ofSize: 13, weight: .medium)
-        detectButton.contentTintColor = .white
         detectButton.wantsLayer = true
-
-        if #available(macOS 11.0, *) {
-            detectButton.bezelColor = NSColor.controlAccentColor
-        } else {
-            detectButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
-        }
 
         view.addSubview(detectButton)
 
@@ -162,6 +161,7 @@ class DownloadViewController: NSViewController {
             detectButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             detectButton.leadingAnchor.constraint(equalTo: urlTextField.trailingAnchor, constant: 8),
             detectButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            detectButton.widthAnchor.constraint(equalToConstant: actionButtonWidth),
             detectButton.heightAnchor.constraint(equalToConstant: 28)
         ])
     }
@@ -218,7 +218,7 @@ class DownloadViewController: NSViewController {
             downloadAllButton.centerYAnchor.constraint(equalTo: statusLabel.centerYAnchor),
             downloadAllButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             downloadAllButton.heightAnchor.constraint(equalToConstant: 26),
-            downloadAllButton.widthAnchor.constraint(equalToConstant: 100)
+            downloadAllButton.widthAnchor.constraint(equalToConstant: actionButtonWidth)
         ])
     }
 
@@ -657,6 +657,10 @@ class DownloadViewController: NSViewController {
 
     @objc private func textFieldDidChange(_ notification: Notification) {
         if let textField = notification.object as? NSTextField, textField == urlTextField {
+            if !isDownloading {
+                clearLoadedPlaylistIfInputChanged()
+                clearActivePlaylistLoadIfInputChanged()
+            }
             updateButtonBasedOnInput()
         }
     }
@@ -679,6 +683,78 @@ class DownloadViewController: NSViewController {
             isSearchMode = true
             isPlaylistMode = false
         }
+    }
+
+    private func clearPlaylistSelection() {
+        selectedPlaylistRows.removeAll()
+        updateDownloadAllButtonTitle()
+    }
+
+    private func clearLoadedPlaylist(resetStatus: Bool = true) {
+        currentPlaylist = nil
+        currentPlaylistURL = nil
+        clearPlaylistSelection()
+        downloadAllButton.isHidden = true
+        tableBackgroundView.isHidden = true
+        scrollView.isHidden = true
+        tableView.reloadData()
+
+        if resetStatus {
+            statusLabel.stringValue = ""
+            statusLabel.textColor = NSColor.secondaryLabelColor
+        }
+    }
+
+    private func clearLoadedPlaylistIfInputChanged(resetStatus: Bool = true) {
+        let text = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if currentPlaylist != nil, currentPlaylistURL != text {
+            clearLoadedPlaylist(resetStatus: resetStatus)
+        }
+    }
+
+    private func clearActivePlaylistLoadIfInputChanged() {
+        let text = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if activePlaylistLoadURL != nil, activePlaylistLoadURL != text {
+            activePlaylistLoadID = nil
+            activePlaylistLoadURL = nil
+            hideProgressIndicator()
+            statusLabel.stringValue = ""
+            statusLabel.textColor = NSColor.secondaryLabelColor
+        }
+    }
+
+    private func updateDownloadAllButtonTitle() {
+        guard !isDownloading else { return }
+        if selectedPlaylistRows.isEmpty {
+            downloadAllButton.title = NSLocalizedString("Download All", comment: "")
+        } else {
+            downloadAllButton.title = String(format: NSLocalizedString("Download %d", comment: ""), selectedPlaylistRows.count)
+        }
+    }
+
+    private func togglePlaylistSelection(at row: Int) {
+        guard isPlaylistMode, !isDownloading else { return }
+        guard let playlist = currentPlaylist, row >= 0, row < playlist.items.count else { return }
+
+        if selectedPlaylistRows.contains(row) {
+            selectedPlaylistRows.remove(row)
+        } else {
+            selectedPlaylistRows.insert(row)
+        }
+
+        updateDownloadAllButtonTitle()
+        tableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integer: 0))
+    }
+
+    private func playlistItemsForDownload() -> [DownloadManager.PlaylistItem] {
+        guard let playlist = currentPlaylist else { return [] }
+        let selectedRows = selectedPlaylistRows.sorted().filter { $0 >= 0 && $0 < playlist.items.count }
+
+        if selectedRows.isEmpty {
+            return playlist.items
+        }
+
+        return selectedRows.map { playlist.items[$0] }
     }
 
     @objc private func handleConfigUpdated() {
@@ -727,6 +803,7 @@ class DownloadViewController: NSViewController {
         if pageToken == nil {
             searchResults = []
             currentNextPageToken = nil
+            clearPlaylistSelection()
             nextPageButton.isHidden = true
             downloadAllButton.isHidden = true
             tableView.reloadData()
@@ -892,6 +969,7 @@ class DownloadViewController: NSViewController {
 
     private func loadPlaylist() {
         let urlString = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let loadID = UUID()
 
         if urlString.isEmpty {
             statusLabel.stringValue = NSLocalizedString("Please enter a valid playlist URL", comment: "")
@@ -910,6 +988,10 @@ class DownloadViewController: NSViewController {
         formats = []
         searchResults = []
         currentPlaylist = nil
+        currentPlaylistURL = nil
+        activePlaylistLoadID = loadID
+        activePlaylistLoadURL = urlString
+        clearPlaylistSelection()
         tableView.reloadData()
         nextPageButton.isHidden = true
         downloadAllButton.isHidden = true
@@ -918,6 +1000,10 @@ class DownloadViewController: NSViewController {
             do {
                 if !self.isYtDlpInstalled {
                     DispatchQueue.main.async {
+                        guard self.activePlaylistLoadID == loadID else { return }
+
+                        self.activePlaylistLoadID = nil
+                        self.activePlaylistLoadURL = nil
                         self.hideProgressIndicator()
                         self.statusLabel.stringValue = NSLocalizedString("yt-dlp not found, please make sure it's installed (brew install yt-dlp)", comment: "")
                         self.statusLabel.textColor = NSColor.systemRed
@@ -927,6 +1013,10 @@ class DownloadViewController: NSViewController {
 
                 if !self.isFfmpegInstalled {
                     DispatchQueue.main.async {
+                        guard self.activePlaylistLoadID == loadID else { return }
+
+                        self.activePlaylistLoadID = nil
+                        self.activePlaylistLoadURL = nil
                         self.hideProgressIndicator()
                         self.statusLabel.stringValue = NSLocalizedString("ffmpeg not found, please make sure it's installed (brew install ffmpeg)", comment: "")
                         self.statusLabel.textColor = NSColor.systemRed
@@ -937,7 +1027,19 @@ class DownloadViewController: NSViewController {
                 let playlistInfo = try await DownloadManager.shared.fetchPlaylistInfo(from: urlString)
 
                 DispatchQueue.main.async {
+                    guard self.activePlaylistLoadID == loadID else { return }
+
+                    guard self.urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) == urlString else {
+                        self.activePlaylistLoadID = nil
+                        self.activePlaylistLoadURL = nil
+                        self.hideProgressIndicator()
+                        return
+                    }
+
+                    self.activePlaylistLoadID = nil
+                    self.activePlaylistLoadURL = nil
                     self.currentPlaylist = playlistInfo
+                    self.currentPlaylistURL = urlString
                     self.hideProgressIndicator()
 
                     if !playlistInfo.items.isEmpty {
@@ -946,6 +1048,7 @@ class DownloadViewController: NSViewController {
                             self.tableBackgroundView.isHidden = false
                             self.scrollView.isHidden = false
                             self.downloadAllButton.isHidden = false
+                            self.updateDownloadAllButtonTitle()
 
                             let maxLength = 40
                             let truncatedTitle = playlistInfo.title.count > maxLength ?
@@ -975,6 +1078,10 @@ class DownloadViewController: NSViewController {
                 }
             } catch {
                 DispatchQueue.main.async {
+                    guard self.activePlaylistLoadID == loadID else { return }
+
+                    self.activePlaylistLoadID = nil
+                    self.activePlaylistLoadURL = nil
                     self.hideProgressIndicator()
                     self.statusLabel.stringValue = String(format: NSLocalizedString("Failed to load playlist: %@", comment: ""), error.localizedDescription)
                     self.statusLabel.textColor = NSColor.systemRed
@@ -1002,6 +1109,7 @@ class DownloadViewController: NSViewController {
         })
 
         formats = []
+        clearPlaylistSelection()
         tableView.reloadData()
 
         nextPageButton.isHidden = true
@@ -1555,7 +1663,16 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             rowView?.identifier = identifier
         }
 
+        rowView?.isMarked = isPlaylistMode && selectedPlaylistRows.contains(row)
         return rowView
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        if isPlaylistMode {
+            togglePlaylistSelection(at: row)
+        }
+
+        return false
     }
 
     private func getFormatOptionCellView(for optionIndex: Int) -> NSView? {
@@ -1699,6 +1816,18 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             durationLabel.alignment = .right
             containerView.addSubview(durationLabel)
 
+            let selectionMarkLabel = NSTextField()
+            selectionMarkLabel.identifier = NSUserInterfaceItemIdentifier("SelectionMarkLabel")
+            selectionMarkLabel.translatesAutoresizingMaskIntoConstraints = false
+            selectionMarkLabel.isEditable = false
+            selectionMarkLabel.isBordered = false
+            selectionMarkLabel.backgroundColor = .clear
+            selectionMarkLabel.drawsBackground = false
+            selectionMarkLabel.font = NSFont.systemFont(ofSize: 16, weight: .semibold)
+            selectionMarkLabel.textColor = NSColor.controlAccentColor
+            selectionMarkLabel.alignment = .center
+            containerView.addSubview(selectionMarkLabel)
+
             NSLayoutConstraint.activate([
                 numberLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 5),
                 numberLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
@@ -1708,11 +1837,17 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                 titleField.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
                 titleField.trailingAnchor.constraint(equalTo: durationLabel.leadingAnchor, constant: -10),
 
-                durationLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5),
+                durationLabel.trailingAnchor.constraint(equalTo: selectionMarkLabel.leadingAnchor, constant: -8),
                 durationLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
-                durationLabel.widthAnchor.constraint(equalToConstant: 60)
+                durationLabel.widthAnchor.constraint(equalToConstant: 60),
+
+                selectionMarkLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -5),
+                selectionMarkLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+                selectionMarkLabel.widthAnchor.constraint(equalToConstant: 18)
             ])
         }
+
+        let isSelected = selectedPlaylistRows.contains(row)
 
         if let numberLabel = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "NumberLabel" }) as? NSTextField {
             numberLabel.stringValue = "\(row + 1)"
@@ -1724,6 +1859,10 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
 
         if let durationLabel = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "DurationLabel" }) as? NSTextField {
             durationLabel.stringValue = item.duration.isEmpty ? "Unknown" : item.duration
+        }
+
+        if let selectionMarkLabel = cell?.subviews.first?.subviews.first(where: { $0.identifier?.rawValue == "SelectionMarkLabel" }) as? NSTextField {
+            selectionMarkLabel.stringValue = isSelected ? "\u{2713}" : ""
         }
 
         return cell
@@ -1757,7 +1896,8 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
             self.activeDownloadButton = nil
         }
 
-        downloadAllButton.title = NSLocalizedString("Download All", comment: "")
+        clearLoadedPlaylistIfInputChanged(resetStatus: false)
+        updateDownloadAllButtonTitle()
         downloadAllButton.contentTintColor = NSColor.white
 
         if #available(macOS 11.0, *) {
@@ -1771,7 +1911,23 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
     }
 
     private func startDownload() {
-        let urlString = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let input = urlTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard isPlaylistMode, currentPlaylistURL == input else {
+            clearLoadedPlaylist()
+            statusLabel.stringValue = NSLocalizedString("Please enter a valid playlist URL", comment: "")
+            statusLabel.textColor = NSColor.systemRed
+            return
+        }
+
+        let items = playlistItemsForDownload()
+        let downloadsSelectedItems = !selectedPlaylistRows.isEmpty
+
+        if items.isEmpty {
+            statusLabel.stringValue = NSLocalizedString("Playlist is empty", comment: "")
+            statusLabel.textColor = NSColor.secondaryLabelColor
+            return
+        }
 
         isDownloading = true
 
@@ -1786,12 +1942,12 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
 
         progressIndicator.isHidden = false
         progressIndicator.startAnimation(nil)
-        statusLabel.stringValue = NSLocalizedString("Starting playlist download...", comment: "")
+        statusLabel.stringValue = NSLocalizedString(downloadsSelectedItems ? "Starting selected downloads..." : "Starting playlist download...", comment: "")
         statusLabel.textColor = NSColor.secondaryLabelColor
 
         downloadTask = Task {
             do {
-                try await DownloadManager.shared.downloadPlaylist(from: urlString) { [weak self] progress in
+                try await DownloadManager.shared.downloadPlaylistItems(items, maxConcurrentDownloads: maxConcurrentPlaylistDownloads) { [weak self] progress in
                     DispatchQueue.main.async {
                         guard let self = self else { return }
                         guard self.isDownloading else { return }
@@ -1817,10 +1973,11 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                     self.downloadTask = nil
                     self.activeDownloadButton = nil
                     self.hideProgressIndicator()
-                    self.statusLabel.stringValue = NSLocalizedString("Playlist download completed", comment: "")
+                    self.statusLabel.stringValue = NSLocalizedString(downloadsSelectedItems ? "Selected downloads completed" : "Playlist download completed", comment: "")
                     self.statusLabel.textColor = NSColor.systemGreen
 
-                    self.downloadAllButton.title = NSLocalizedString("Download All", comment: "")
+                    self.clearLoadedPlaylistIfInputChanged(resetStatus: false)
+                    self.updateDownloadAllButtonTitle()
                     self.downloadAllButton.contentTintColor = NSColor.white
 
                     if #available(macOS 11.0, *) {
@@ -1841,10 +1998,12 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                     self.downloadTask = nil
                     self.activeDownloadButton = nil
                     self.hideProgressIndicator()
-                    self.statusLabel.stringValue = String(format: NSLocalizedString("Playlist download failed: %@", comment: ""), error.localizedDescription)
+                    let errorKey = downloadsSelectedItems ? "Selected downloads failed: %@" : "Playlist download failed: %@"
+                    self.statusLabel.stringValue = String(format: NSLocalizedString(errorKey, comment: ""), error.localizedDescription)
                     self.statusLabel.textColor = NSColor.systemRed
 
-                    self.downloadAllButton.title = NSLocalizedString("Download All", comment: "")
+                    self.clearLoadedPlaylistIfInputChanged(resetStatus: false)
+                    self.updateDownloadAllButtonTitle()
                     self.downloadAllButton.contentTintColor = NSColor.white
 
                     if #available(macOS 11.0, *) {

--- a/MacMusicPlayer/Managers/DownloadManager.swift
+++ b/MacMusicPlayer/Managers/DownloadManager.swift
@@ -318,8 +318,7 @@ public class DownloadManager {
             if result.terminationStatus == 0 {
                 let title = result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !title.isEmpty {
-                    let invalidChars = CharacterSet(charactersIn: "\\/:*?\"<>|")
-                    return title.components(separatedBy: invalidChars).joined(separator: "_")
+                    return sanitizedFileTitle(title)
                 }
             }
 
@@ -330,6 +329,13 @@ public class DownloadManager {
             print(NSLocalizedString("Error getting video title: %@", comment: "Log message when getting video title fails"), error)
             throw DownloadError.titleFetchFailed
         }
+    }
+
+    private func sanitizedFileTitle(_ title: String) -> String {
+        let invalidChars = CharacterSet(charactersIn: "\\/:*?\"<>|")
+        let sanitizedTitle = title.components(separatedBy: invalidChars).joined(separator: "_")
+        let trimmedTitle = sanitizedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedTitle.isEmpty ? "Unknown Title" : trimmedTitle
     }
 
     public func fetchAvailableFormats(from url: String) async throws -> [DownloadFormat] {
@@ -575,7 +581,7 @@ public class DownloadManager {
         return uniqueFormats
     }
 
-    public func downloadAudio(from url: String, formatId: String) async throws {
+    public func downloadAudio(from url: String, formatId: String, outputTitle: String? = nil) async throws {
         print(NSLocalizedString("Starting audio download, URL: %@, Format ID: %@", comment: "Log message when starting download"), url, formatId)
 
         guard URL(string: url) != nil else {
@@ -587,7 +593,12 @@ public class DownloadManager {
         let ytDlpPath = try checkYtDlpAvailability()
         let ffmpegPath = try checkFFmpegAvailability()
 
-        let videoTitle = try await getVideoTitle(from: url, ytDlpPath: ytDlpPath)
+        let videoTitle: String
+        if let outputTitle = outputTitle {
+            videoTitle = sanitizedFileTitle(outputTitle)
+        } else {
+            videoTitle = try await getVideoTitle(from: url, ytDlpPath: ytDlpPath)
+        }
         try Task.checkCancellation()
         print(NSLocalizedString("Video title: %@", comment: "Log message showing video title"), videoTitle)
 
@@ -768,6 +779,33 @@ public class DownloadManager {
         return "unknown"
     }
 
+    private func outputTitles(forPlaylistItems items: [PlaylistItem]) -> [String] {
+        let baseTitles = items.map { sanitizedFileTitle($0.title) }
+        let titleCounts = Dictionary(grouping: baseTitles, by: { $0 }).mapValues(\.count)
+        var occurrences: [String: Int] = [:]
+        var usedTitles = Set<String>()
+
+        return baseTitles.map { title in
+            var candidate = title
+            var occurrence = occurrences[title] ?? 0
+
+            if titleCounts[title, default: 0] > 1 {
+                occurrence += 1
+                occurrences[title] = occurrence
+                candidate = "\(title) [\(occurrence)]"
+            }
+
+            while usedTitles.contains(candidate) {
+                occurrence += 1
+                candidate = "\(title) [\(occurrence)]"
+            }
+
+            occurrences[title] = occurrence
+            usedTitles.insert(candidate)
+            return candidate
+        }
+    }
+
     public func downloadPlaylist(
         from url: String,
         progressCallback: @escaping (PlaylistDownloadProgress) -> Void
@@ -776,41 +814,117 @@ public class DownloadManager {
 
         try Task.checkCancellation()
         let playlistInfo = try await fetchPlaylistInfo(from: url)
+        try await downloadPlaylistItems(playlistInfo.items, progressCallback: progressCallback)
+    }
+
+    public func downloadPlaylistItems(
+        _ items: [PlaylistItem],
+        maxConcurrentDownloads: Int = 3,
+        progressCallback: @escaping (PlaylistDownloadProgress) -> Void
+    ) async throws {
+        if items.isEmpty {
+            throw DownloadError.playlistDownloadFailed(NSLocalizedString("Playlist is empty", comment: "Error when playlist has no downloadable items"))
+        }
+
         var completed = 0
         var failed = 0
+        var started = 0
+        var nextIndex = 0
+        let totalCount = items.count
+        let concurrentLimit = max(1, min(maxConcurrentDownloads, totalCount))
+        let outputTitles = outputTitles(forPlaylistItems: items)
 
-        for (index, item) in playlistInfo.items.enumerated() {
-            try Task.checkCancellation()
+        try await withThrowingTaskGroup(of: (PlaylistItem, Bool).self) { group in
+            while nextIndex < concurrentLimit {
+                let item = items[nextIndex]
+                let outputTitle = outputTitles[nextIndex]
+                nextIndex += 1
+                started += 1
 
-            let progress = PlaylistDownloadProgress(
-                currentIndex: index + 1,
-                totalCount: playlistInfo.videoCount,
-                currentTitle: item.title,
-                completed: completed,
-                failed: failed
-            )
+                let progress = PlaylistDownloadProgress(
+                    currentIndex: started,
+                    totalCount: totalCount,
+                    currentTitle: item.title,
+                    completed: completed,
+                    failed: failed
+                )
 
-            await MainActor.run {
-                progressCallback(progress)
+                await MainActor.run {
+                    progressCallback(progress)
+                }
+
+                group.addTask {
+                    do {
+                        try await self.downloadAudio(from: item.url, formatId: "bestaudio", outputTitle: outputTitle)
+                        return (item, true)
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        print(String(format: NSLocalizedString("Failed to download: %@ - Error: %@", comment: "Log message when item download fails"), item.title, error.localizedDescription))
+                        return (item, false)
+                    }
+                }
             }
-            try Task.checkCancellation()
 
-            do {
-                try await downloadAudio(from: item.url, formatId: "bestaudio")
-                completed += 1
-                print(NSLocalizedString("Successfully downloaded: %@", comment: "Log message when item downloaded successfully"), item.title)
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                failed += 1
-                print(NSLocalizedString("Failed to download: %@ - Error: %@", comment: "Log message when item download fails"), item.title, error.localizedDescription)
+            while let (item, succeeded) = try await group.next() {
+                if succeeded {
+                    completed += 1
+                    print(String(format: NSLocalizedString("Successfully downloaded: %@", comment: "Log message when item downloaded successfully"), item.title))
+                } else {
+                    failed += 1
+                }
+
+                let progress = PlaylistDownloadProgress(
+                    currentIndex: min(started, totalCount),
+                    totalCount: totalCount,
+                    currentTitle: item.title,
+                    completed: completed,
+                    failed: failed
+                )
+
+                await MainActor.run {
+                    progressCallback(progress)
+                }
+
+                try Task.checkCancellation()
+
+                if nextIndex < totalCount {
+                    let nextItem = items[nextIndex]
+                    let nextOutputTitle = outputTitles[nextIndex]
+                    nextIndex += 1
+                    started += 1
+
+                    let nextProgress = PlaylistDownloadProgress(
+                        currentIndex: started,
+                        totalCount: totalCount,
+                        currentTitle: nextItem.title,
+                        completed: completed,
+                        failed: failed
+                    )
+
+                    await MainActor.run {
+                        progressCallback(nextProgress)
+                    }
+
+                    group.addTask {
+                        do {
+                            try await self.downloadAudio(from: nextItem.url, formatId: "bestaudio", outputTitle: nextOutputTitle)
+                            return (nextItem, true)
+                        } catch is CancellationError {
+                            throw CancellationError()
+                        } catch {
+                            print(String(format: NSLocalizedString("Failed to download: %@ - Error: %@", comment: "Log message when item download fails"), nextItem.title, error.localizedDescription))
+                            return (nextItem, false)
+                        }
+                    }
+                }
             }
         }
 
         try Task.checkCancellation()
         let finalProgress = PlaylistDownloadProgress(
-            currentIndex: playlistInfo.videoCount,
-            totalCount: playlistInfo.videoCount,
+            currentIndex: totalCount,
+            totalCount: totalCount,
             currentTitle: NSLocalizedString("Completed", comment: "Download completion status"),
             completed: completed,
             failed: failed
@@ -824,6 +938,6 @@ public class DownloadManager {
             throw DownloadError.playlistDownloadFailed(NSLocalizedString("All downloads failed", comment: "Error when all playlist downloads fail"))
         }
 
-        print(NSLocalizedString("Playlist download completed: %d successful, %d failed", comment: "Log message when playlist download completes"), completed, failed)
+        print(String(format: NSLocalizedString("Playlist download completed: %d successful, %d failed", comment: "Log message when playlist download completes"), completed, failed))
     }
 }

--- a/MacMusicPlayer/Resources/Localization/en.lproj/Localizable.strings
+++ b/MacMusicPlayer/Resources/Localization/en.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 "Details" = "Details";
 "Load Playlist" = "Load Playlist";
 "Download All" = "Download All";
+"Download %d" = "Download %d";
+"Download Selected" = "Download Selected";
 "Stop" = "Stop";
 "Download stopped" = "Download stopped";
 
@@ -143,9 +145,12 @@
 "Playlist is empty" = "Playlist is empty";
 "Failed to load playlist: %@" = "Failed to load playlist: %@";
 "Starting playlist download..." = "Starting playlist download...";
+"Starting selected downloads..." = "Starting selected downloads...";
 "Downloading (%d/%d) - %@" = "Downloading (%d/%d) - %@";
 "Playlist download completed" = "Playlist download completed";
+"Selected downloads completed" = "Selected downloads completed";
 "Playlist download failed: %@" = "Playlist download failed: %@";
+"Selected downloads failed: %@" = "Selected downloads failed: %@";
 
 // Song Picker Window Status
 "search_songs_placeholder" = "Search songs...";

--- a/MacMusicPlayer/Resources/Localization/ja.lproj/Localizable.strings
+++ b/MacMusicPlayer/Resources/Localization/ja.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 "Details" = "詳細";
 "Load Playlist" = "プレイリスト読み込み";
 "Download All" = "すべてダウンロード";
+"Download %d" = "%d 件をダウンロード";
+"Download Selected" = "選択項目をダウンロード";
 "Stop" = "停止";
 "Download stopped" = "ダウンロード停止";
 
@@ -143,9 +145,12 @@
 "Playlist is empty" = "プレイリストが空です";
 "Failed to load playlist: %@" = "プレイリストの読み込みに失敗しました：%@";
 "Starting playlist download..." = "プレイリストダウンロードを開始...";
+"Starting selected downloads..." = "選択項目のダウンロードを開始...";
 "Downloading (%d/%d) - %@" = "ダウンロード中 (%d/%d) - %@";
 "Playlist download completed" = "プレイリストダウンロード完了";
+"Selected downloads completed" = "選択項目のダウンロード完了";
 "Playlist download failed: %@" = "プレイリストダウンロードに失敗しました：%@";
+"Selected downloads failed: %@" = "選択項目のダウンロードに失敗しました：%@";
 
 // Song Picker Window Status
 "search_songs_placeholder" = "曲を検索...";

--- a/MacMusicPlayer/Resources/Localization/ko.lproj/Localizable.strings
+++ b/MacMusicPlayer/Resources/Localization/ko.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 "Details" = "상세 정보";
 "Load Playlist" = "재생목록 로드";
 "Download All" = "모두 다운로드";
+"Download %d" = "%d개 다운로드";
+"Download Selected" = "선택 항목 다운로드";
 "Stop" = "중지";
 "Download stopped" = "다운로드 중지됨";
 
@@ -143,9 +145,12 @@
 "Playlist is empty" = "재생목록이 비어있습니다";
 "Failed to load playlist: %@" = "재생목록 로드 실패: %@";
 "Starting playlist download..." = "재생목록 다운로드 시작...";
+"Starting selected downloads..." = "선택 항목 다운로드 시작...";
 "Downloading (%d/%d) - %@" = "다운로드 중 (%d/%d) - %@";
 "Playlist download completed" = "재생목록 다운로드 완료";
+"Selected downloads completed" = "선택 항목 다운로드 완료";
 "Playlist download failed: %@" = "재생목록 다운로드 실패: %@";
+"Selected downloads failed: %@" = "선택 항목 다운로드 실패: %@";
 
 // Song Picker Window Status
 "search_songs_placeholder" = "곡 검색...";

--- a/MacMusicPlayer/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/MacMusicPlayer/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 "Details" = "详情";
 "Load Playlist" = "加载播放列表";
 "Download All" = "全部下载";
+"Download %d" = "下载 %d 项";
+"Download Selected" = "下载选中项";
 "Stop" = "停止";
 "Download stopped" = "下载已停止";
 
@@ -143,9 +145,12 @@
 "Playlist is empty" = "播放列表为空";
 "Failed to load playlist: %@" = "加载播放列表失败：%@";
 "Starting playlist download..." = "开始下载播放列表...";
+"Starting selected downloads..." = "开始下载选中项...";
 "Downloading (%d/%d) - %@" = "正在下载 (%d/%d) - %@";
 "Playlist download completed" = "播放列表下载完成";
+"Selected downloads completed" = "选中项下载完成";
 "Playlist download failed: %@" = "播放列表下载失败：%@";
+"Selected downloads failed: %@" = "选中项下载失败：%@";
 
 // Song Picker Window Status
 "search_songs_placeholder" = "搜索歌曲...";

--- a/MacMusicPlayer/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/MacMusicPlayer/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 "Details" = "詳細";
 "Load Playlist" = "載入播放列表";
 "Download All" = "全部下載";
+"Download %d" = "下載 %d 項";
+"Download Selected" = "下載選中項";
 "Stop" = "停止";
 "Download stopped" = "下載已停止";
 
@@ -143,9 +145,12 @@
 "Playlist is empty" = "播放列表為空";
 "Failed to load playlist: %@" = "載入播放列表失敗：%@";
 "Starting playlist download..." = "開始下載播放列表...";
+"Starting selected downloads..." = "開始下載選中項...";
 "Downloading (%d/%d) - %@" = "正在下載 (%d/%d) - %@";
 "Playlist download completed" = "播放列表下載完成";
+"Selected downloads completed" = "選中項下載完成";
 "Playlist download failed: %@" = "播放列表下載失敗：%@";
+"Selected downloads failed: %@" = "選中項下載失敗：%@";
 
 // Song Picker Window Status
 "search_songs_placeholder" = "搜尋歌曲...";

--- a/MacMusicPlayer/Views/CustomTableRowView.swift
+++ b/MacMusicPlayer/Views/CustomTableRowView.swift
@@ -1,6 +1,14 @@
 import Cocoa
 
 class CustomTableRowView: NSTableRowView {
+    var isMarked = false {
+        didSet {
+            updateBackgroundColor(animated: false)
+        }
+    }
+
+    private var isHovering = false
+
     override func drawSelection(in dirtyRect: NSRect) {
         if self.selectionHighlightStyle != .none {
             super.drawSelection(in: dirtyRect)
@@ -32,20 +40,36 @@ class CustomTableRowView: NSTableRowView {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
-        self.wantsLayer = true
-
-        NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.2
-            self.animator().layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.1).cgColor
-        })
+        isHovering = true
+        updateBackgroundColor(animated: true)
     }
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
+        isHovering = false
+        updateBackgroundColor(animated: true)
+    }
+
+    private func updateBackgroundColor(animated: Bool) {
+        wantsLayer = true
+
+        let alpha: CGFloat
+        if isMarked {
+            alpha = isHovering ? 0.24 : 0.18
+        } else {
+            alpha = isHovering ? 0.1 : 0
+        }
+
+        let color = NSColor.controlAccentColor.withAlphaComponent(alpha).cgColor
+
+        if !animated {
+            layer?.backgroundColor = color
+            return
+        }
 
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.2
-            self.animator().layer?.backgroundColor = NSColor.clear.cgColor
+            self.animator().layer?.backgroundColor = color
         })
     }
 }


### PR DESCRIPTION
### What changed?

- Add row-based playlist item selection with persistent highlight and checkmark UI.
- Download selected playlist items when rows are marked, while preserving full playlist download when none are selected.
- Run playlist item downloads concurrently with bounded parallelism and unique sanitized output titles.
- Keep playlist state tied to the loaded URL so stale input changes cannot download or display old playlist data.

### Why

- Users need to download only selected playlist items instead of always downloading the whole playlist.

### Verification

- make build
- make VERSION=PR-086b104 dmg
- make check-arch
- plutil -lint MacMusicPlayer/Resources/Localization/*.lproj/Localizable.strings
- git diff --check HEAD^ HEAD
- codex review --commit HEAD --title "feat(download): add selected playlist downloads"
