### PR TITLE
fix(library): avoid duplicate library reloads

### DIFF
--- a/MacMusicPlayer/AppDelegate.swift
+++ b/MacMusicPlayer/AppDelegate.swift
@@ -203,10 +203,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         libraryManager.switchLibrary(id: libraryId)
 
-        if let currentLibrary = libraryManager.currentLibrary {
-            playerManager.loadLibrary(currentLibrary)
-        }
-
         statusMenuController.refresh()
     }
 
@@ -229,10 +225,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if alert.runModal() == .alertFirstButtonReturn {
             libraryManager.removeLibrary(id: currentId)
-
-            if let newCurrent = libraryManager.currentLibrary {
-                playerManager.loadLibrary(newCurrent)
-            }
 
             statusMenuController.refresh()
         }


### PR DESCRIPTION
### What's changed?

- Remove redundant library reloads from the menu switch and current-library removal flows.
- Keep RefreshMusicLibrary as the single reload path for library state changes.

### Why

- Switching or removing the active library already posts RefreshMusicLibrary.
- The extra AppDelegate calls caused duplicate filesystem scans and queue rebuilds.

### Verification

- xcodebuild with MACOSX_DEPLOYMENT_TARGET=12.0
- git diff --check
- Verified call-path counts: switch=0, remove=0, observer=1, library_posts=2, startup=1, manual_refresh=1
