### PR TITLE
fix(playback): clear stale state after item failure

### DIFF
--- a/MacMusicPlayer/Managers/QueuePlayerController.swift
+++ b/MacMusicPlayer/Managers/QueuePlayerController.swift
@@ -6,17 +6,21 @@ class QueuePlayerController: NSObject, PlaybackControlling {
     private var playerItems: [AVPlayerItem] = []
     private var tracks: [Track] = []
     private var currentTrackIndex: Int = 0
+    private var currentItemStatusObservation: NSKeyValueObservation?
 
     var onTrackChanged: ((Track?) -> Void)?
     var onPlaybackStateChanged: ((Bool) -> Void)?
     var onTrackFinished: ((Track?) -> Void)?
 
     var isPlaying: Bool {
-        queuePlayer.rate > 0
+        guard let currentItem = queuePlayer.currentItem else { return false }
+        return currentItem.status != .failed && queuePlayer.rate > 0
     }
 
     var currentTrack: Track? {
-        guard currentTrackIndex < tracks.count else { return nil }
+        guard let currentItem = queuePlayer.currentItem,
+              currentItem.status != .failed,
+              currentTrackIndex < tracks.count else { return nil }
         return tracks[currentTrackIndex]
     }
 
@@ -60,6 +64,7 @@ class QueuePlayerController: NSObject, PlaybackControlling {
     }
 
     private func removeObservers() {
+        currentItemStatusObservation = nil
         NotificationCenter.default.removeObserver(self)
         queuePlayer.removeObserver(self, forKeyPath: "rate")
         queuePlayer.removeObserver(self, forKeyPath: "currentItem")
@@ -69,8 +74,24 @@ class QueuePlayerController: NSObject, PlaybackControlling {
         if keyPath == "rate" {
             onPlaybackStateChanged?(isPlaying)
         } else if keyPath == "currentItem" {
+            observeCurrentItemStatus()
+            guard queuePlayer.currentItem != nil else { return }
             updateCurrentTrackIndex()
             onTrackChanged?(currentTrack)
+            onPlaybackStateChanged?(isPlaying)
+        }
+    }
+
+    private func observeCurrentItemStatus() {
+        currentItemStatusObservation = queuePlayer.currentItem?.observe(\.status, options: [.initial, .new]) { [weak self] item, _ in
+            guard item.status == .failed else { return }
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      self.queuePlayer.currentItem == nil || self.queuePlayer.currentItem === item else { return }
+                self.onTrackChanged?(nil)
+                self.onPlaybackStateChanged?(false)
+            }
         }
     }
 


### PR DESCRIPTION
### What's changed?

- Observe the current `AVPlayerItem` status and clear stale track/playback state when it fails.
- Treat missing or failed queue items as not playing and not current.
- Preserve normal queue transitions without exposing transient empty state.

### Why

- Missing, moved, or damaged audio files could leave the menu and media state reporting a track as active after playback had already failed.

### Verification

- `.local/playback-state-probe/probe broken .local/playback-state-probe/broken`
- `.local/playback-state-probe/probe normal .local/playback-state-probe/normal`
- `.local/playback-state-probe/probe normal .local/playback-state-probe/mixed`
- `xcodebuild -project MacMusicPlayer.xcodeproj -scheme MacMusicPlayer -configuration Debug MACOSX_DEPLOYMENT_TARGET=12.0 CODE_SIGNING_ALLOWED=NO build`

## Considered and deferred

- Retry behavior and a dedicated playback-error UI require a separate product decision; this change only corrects stale state.
- Main-thread ownership for all existing KVO callbacks should be corrected as a separate callback-boundary change.
- Logging `AVPlayerItem.error` would improve diagnostics but does not affect state correctness.