### PR TITLE
fix(playback): preserve state when navigating tracks

### DIFF
--- a/MacMusicPlayer/Managers/PlayerManager.swift
+++ b/MacMusicPlayer/Managers/PlayerManager.swift
@@ -248,7 +248,7 @@ class PlayerManager: NSObject, ObservableObject {
         currentTrack = tracks[index]
         queueController.play()
         isPlaying = true
-        updateNowPlayingInfo()
+        updateNowPlayingInfo(playbackState: .playing)
     }
 
     func clearQueue() {
@@ -261,6 +261,7 @@ class PlayerManager: NSObject, ObservableObject {
 
     func playNext() {
         guard !playlistStore.isEmpty else { return }
+        let shouldResumePlayback = nowPlayingPlaybackState == .playing
 
         guard let nextIndex = playlistStore.nextIndex(for: playMode) else {
             return
@@ -276,14 +277,15 @@ class PlayerManager: NSObject, ObservableObject {
                 queueController.setQueue(playlistStore.tracks, startingAt: 0)
                 playlistStore.setCurrentIndex(0)
                 currentIndex = 0
-                queueController.play()
             }
         case .singleLoop:
             queueController.stop()
-            queueController.play()
         case .random:
             queueController.setQueue(playlistStore.tracks, startingAt: nextIndex)
             currentIndex = nextIndex
+        }
+
+        if shouldResumePlayback {
             queueController.play()
         }
 
@@ -294,6 +296,7 @@ class PlayerManager: NSObject, ObservableObject {
 
     func playPrevious() {
         guard !playlistStore.isEmpty else { return }
+        let shouldResumePlayback = nowPlayingPlaybackState == .playing
 
         switch playMode {
         case .sequential, .random:
@@ -302,11 +305,13 @@ class PlayerManager: NSObject, ObservableObject {
             queueController.setQueue(playlistStore.tracks, startingAt: previousIndex)
             playlistStore.setCurrentIndex(previousIndex)
             currentIndex = previousIndex
-            queueController.play()
 
             currentTrack = playlistStore.currentTrack
         case .singleLoop:
             queueController.stop()
+        }
+
+        if shouldResumePlayback {
             queueController.play()
         }
 


### PR DESCRIPTION
### What's changed?

- Preserve the current playing, paused, or stopped intent when navigating with Next or Previous.
- Apply the same transport behavior across sequential, random, and single-loop modes.
- Keep explicit track selection as a play action.

### Why

- Previous and most non-sequential navigation paths called `play()` unconditionally, causing paused or stopped playback to start unexpectedly.

### Verification

- Navigation state probe: 18 combinations across three playback modes, three transport states, and Next/Previous passed in three consecutive runs.
- Now Playing state probe passed.
- Existing broken, normal, and mixed playback probes passed.
- `xcodebuild -project MacMusicPlayer.xcodeproj -scheme MacMusicPlayer -configuration Debug MACOSX_DEPLOYMENT_TARGET=12.0 CODE_SIGNING_ALLOWED=NO build`