### PR TITLE
fix(playback): honor transport commands in single-loop mode

### DIFF
--- a/MacMusicPlayer/Managers/PlayerManager.swift
+++ b/MacMusicPlayer/Managers/PlayerManager.swift
@@ -278,9 +278,7 @@ class PlayerManager: NSObject, ObservableObject {
                 playlistStore.setCurrentIndex(0)
                 currentIndex = 0
             }
-        case .singleLoop:
-            queueController.stop()
-        case .random:
+        case .singleLoop, .random:
             queueController.setQueue(playlistStore.tracks, startingAt: nextIndex)
             currentIndex = nextIndex
         }
@@ -299,16 +297,16 @@ class PlayerManager: NSObject, ObservableObject {
         let shouldResumePlayback = nowPlayingPlaybackState == .playing
 
         switch playMode {
-        case .sequential, .random:
-            guard let previousIndex = playlistStore.previousIndex() else { return }
+        case .sequential, .singleLoop, .random:
+            let previousIndex = playlistStore.previousIndex()
+                ?? (playMode == .singleLoop ? playlistStore.currentIndex : nil)
+            guard let previousIndex else { return }
 
             queueController.setQueue(playlistStore.tracks, startingAt: previousIndex)
             playlistStore.setCurrentIndex(previousIndex)
             currentIndex = previousIndex
 
             currentTrack = playlistStore.currentTrack
-        case .singleLoop:
-            queueController.stop()
         }
 
         if shouldResumePlayback {

--- a/MacMusicPlayer/Managers/PlaylistStore.swift
+++ b/MacMusicPlayer/Managers/PlaylistStore.swift
@@ -26,7 +26,7 @@ class PlaylistStore: ObservableObject {
 
     func nextIndex(for playMode: PlayMode) -> Int? {
         switch playMode {
-        case .sequential:
+        case .sequential, .singleLoop:
             guard !tracks.isEmpty else { return nil }
             return (currentIndex + 1) % tracks.count
 
@@ -37,9 +37,6 @@ class PlaylistStore: ObservableObject {
                 randomIndex = Int.random(in: 0..<tracks.count)
             }
             return randomIndex
-
-        case .singleLoop:
-            return currentIndex
         }
     }
 


### PR DESCRIPTION
### What's changed?

- Make explicit Next and Previous actions navigate tracks in single-loop mode.
- Keep natural track completion repeating the current track.
- Preserve playing, paused, and stopped state while navigating.

### Why

- Single-loop mode incorrectly treated explicit transport commands as repeat-current actions, so menu, media-key, and system Next/Previous controls did not select the adjacent track.

### Verification

- Single-loop transport probe: Next/Previous passed across playing, paused, and stopped states.
- Natural-completion probe confirmed the current track still repeats.
- Navigation state probe: 18/18 combinations passed.
- Now Playing and normal/broken playback probes passed.
- `xcodebuild -project MacMusicPlayer.xcodeproj -scheme MacMusicPlayer -configuration Debug -derivedDataPath .local/DerivedData MACOSX_DEPLOYMENT_TARGET=12.0 CODE_SIGNING_ALLOWED=NO build` passed with the macOS 27 SDK.