### PR TITLE
fix(build): restore make build on Xcode 27

### DIFF
--- a/MacMusicPlayer.xcodeproj/project.pbxproj
+++ b/MacMusicPlayer.xcodeproj/project.pbxproj
@@ -294,7 +294,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.seimotech.MacMusicPlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -329,7 +329,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.seimotech.MacMusicPlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MacMusicPlayer/Info.plist
+++ b/MacMusicPlayer/Info.plist
@@ -28,7 +28,7 @@
     <key>LSBackgroundOnly</key>
     <false/>
     <key>LSMinimumSystemVersion</key>
-    <string>11.5</string>
+    <string>12.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
### What changed?

- Raise the app target deployment version from macOS 11.5 to macOS 12.0 for Debug and Release.
- Align the source Info.plist with the existing macOS 12.0 requirement in the README.

### Why

- Xcode 27 supports deployment targets starting at macOS 12.0, so make build failed with error 65 while the target still declared macOS 11.5.

### Verification

- make build succeeds with the macOS 27 SDK.
- Debug and Release resolve MACOSX_DEPLOYMENT_TARGET to 12.0.
- The built app Info.plist and Mach-O load command both declare macOS 12.0.
- codesign verification succeeds.