### PR TITLE
Preserve playback during library refresh

### DIFF
--- a/MacMusicPlayer/Controllers/DownloadViewController.swift
+++ b/MacMusicPlayer/Controllers/DownloadViewController.swift
@@ -1254,7 +1254,6 @@ class DownloadViewController: NSViewController {
                         sender.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
                     }
 
-                    NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
                 }
             } catch {
                 DispatchQueue.main.async {
@@ -1986,7 +1985,6 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                         self.downloadAllButton.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
                     }
 
-                    NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
                 }
             } catch {
                 DispatchQueue.main.async {
@@ -2030,7 +2028,6 @@ extension DownloadViewController: NSTableViewDataSource, NSTableViewDelegate {
                     self.statusLabel.stringValue = NSLocalizedString("Download completed", comment: "")
                     self.statusLabel.textColor = NSColor.systemGreen
 
-                    NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
                 }
             } catch {
                 DispatchQueue.main.async {

--- a/MacMusicPlayer/Managers/DownloadManager.swift
+++ b/MacMusicPlayer/Managers/DownloadManager.swift
@@ -636,10 +636,6 @@ public class DownloadManager {
 
             if result.terminationStatus == 0 {
                 print(NSLocalizedString("Download successful", comment: "Log message when download succeeds"))
-
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
-                }
             } else {
                 print(NSLocalizedString("Download failed, exit status: %d", comment: "Log message when download fails"), result.terminationStatus)
                 throw DownloadError.downloadFailed(result.standardError)

--- a/MacMusicPlayer/Managers/DownloadManager.swift
+++ b/MacMusicPlayer/Managers/DownloadManager.swift
@@ -636,6 +636,10 @@ public class DownloadManager {
 
             if result.terminationStatus == 0 {
                 print(NSLocalizedString("Download successful", comment: "Log message when download succeeds"))
+
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: NSNotification.Name("RefreshMusicLibrary"), object: nil)
+                }
             } else {
                 print(NSLocalizedString("Download failed, exit status: %d", comment: "Log message when download fails"), result.terminationStatus)
                 throw DownloadError.downloadFailed(result.standardError)

--- a/MacMusicPlayer/Managers/PlayerManager.swift
+++ b/MacMusicPlayer/Managers/PlayerManager.swift
@@ -155,20 +155,29 @@ class PlayerManager: NSObject, ObservableObject {
 
     func loadLibrary(_ library: MusicLibrary) {
         currentLibraryID = library.id
-        queueController.clearQueue()
-        nowPlayingPlaybackState = .stopped
-        currentTrack = nil
-        isPlaying = false
-        updateNowPlayingInfo(playbackState: .stopped)
-        currentIndex = 0
+        resetPlayback()
 
         playlist = []
 
         loadTracksFromMusicFolder(URL(fileURLWithPath: library.path), libraryID: library.id)
     }
 
-    private func loadTracksFromMusicFolder(_ folderURL: URL, libraryID: UUID) {
+    private func resetPlayback() {
+        queueController.clearQueue()
+        nowPlayingPlaybackState = .stopped
+        currentTrack = nil
+        isPlaying = false
+        updateNowPlayingInfo(playbackState: .stopped)
+        currentIndex = 0
+    }
+
+    private func loadTracksFromMusicFolder(
+        _ folderURL: URL,
+        libraryID: UUID,
+        preservingCurrentItem: Bool = false
+    ) {
         let fileManager = FileManager.default
+        let existingTracksByPath = Dictionary(uniqueKeysWithValues: playlist.map { ($0.url.path, $0) })
 
         guard let enumerator = fileManager.enumerator(at: folderURL,
                                                     includingPropertiesForKeys: [.isRegularFileKey],
@@ -191,7 +200,8 @@ class PlayerManager: NSObject, ObservableObject {
                     title = String(fileName[range.upperBound...]).trimmingCharacters(in: .whitespaces)
                 }
 
-                let track = Track(id: UUID(), title: title, artist: artist, url: fileURL)
+                let track = existingTracksByPath[fileURL.path]
+                    ?? Track(id: UUID(), title: title, artist: artist, url: fileURL)
                 newPlaylist.append(track)
             }
         }
@@ -200,8 +210,25 @@ class PlayerManager: NSObject, ObservableObject {
             guard self.currentLibraryID == libraryID else { return }
             let sortedTracks = newPlaylist.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
-            self.playlistStore.setTracks(sortedTracks)
+            if preservingCurrentItem,
+               let currentPath = self.currentTrack?.url.path,
+               let currentIndex = sortedTracks.firstIndex(where: { $0.url.path == currentPath }),
+               self.queueController.replaceTracks(sortedTracks, preservingCurrentTrackAt: currentIndex) {
+                self.playlistStore.setTracks(sortedTracks)
+                self.playlistStore.setCurrentIndex(currentIndex)
+                self.currentIndex = currentIndex
+                self.playlist = sortedTracks
+                self.currentTrack = sortedTracks[currentIndex]
+                self.updateNowPlayingInfo()
+                NotificationCenter.default.post(name: NSNotification.Name("PlaylistUpdated"), object: nil)
+                return
+            }
 
+            if preservingCurrentItem {
+                self.resetPlayback()
+            }
+
+            self.playlistStore.setTracks(sortedTracks)
             self.playlist = sortedTracks
 
             if !sortedTracks.isEmpty {
@@ -336,7 +363,15 @@ class PlayerManager: NSObject, ObservableObject {
     @MainActor
     @objc func refreshMusicLibrary() {
         if let library = (NSApplication.shared.delegate as? AppDelegate)?.libraryManager.currentLibrary {
-            loadLibrary(library)
+            if currentLibraryID == library.id {
+                loadTracksFromMusicFolder(
+                    URL(fileURLWithPath: library.path),
+                    libraryID: library.id,
+                    preservingCurrentItem: true
+                )
+            } else {
+                loadLibrary(library)
+            }
         } else {
             loadSavedMusicFolder()
         }

--- a/MacMusicPlayer/Managers/QueuePlayerController.swift
+++ b/MacMusicPlayer/Managers/QueuePlayerController.swift
@@ -146,6 +146,25 @@ class QueuePlayerController: NSObject, PlaybackControlling {
         appendNextItemIfNeeded()
     }
 
+    func replaceTracks(_ newTracks: [Track], preservingCurrentTrackAt index: Int) -> Bool {
+        guard newTracks.indices.contains(index),
+              let currentItem = queuePlayer.currentItem,
+              tracks.indices.contains(currentTrackIndex),
+              tracks[currentTrackIndex].url.path == newTracks[index].url.path else {
+            return false
+        }
+
+        for item in queuePlayer.items().dropFirst() {
+            queuePlayer.remove(item)
+        }
+
+        tracks = newTracks
+        currentTrackIndex = index
+        itemIndices = [ObjectIdentifier(currentItem): index]
+        appendNextItemIfNeeded()
+        return true
+    }
+
     func advanceToNext() -> Bool {
         guard currentTrackIndex < tracks.count - 1 else { return false }
         appendNextItemIfNeeded()


### PR DESCRIPTION
## What changed

- preserve the active AVPlayerItem when refreshing the current library
- rebuild only queued follow-up items against the refreshed track list
- retain track identity by file path
- remove duplicate library refresh notifications from DownloadManager

## Why

A successful download refresh previously reused the destructive library-loading path, which cleared the playback queue and stopped the current track.

## Validation

- source-compiled playback refresh probe: PASS
- make build: PASS
- git diff --check: PASS

## Residual risk

The real yt-dlp download UI flow was not manually exercised; notification placement remains on the existing success-only controller paths.